### PR TITLE
Load library contents asynchronously

### DIFF
--- a/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
+++ b/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
@@ -144,6 +144,13 @@ public class LocalMusicStore implements MusicStore {
             mAlbums = BehaviorSubject.create();
 
             MediaStoreUtil.getPermission(mContext)
+                    .flatMap(granted -> {
+                        if (noDirectoryFilters()) {
+                            return Observable.just(granted);
+                        } else {
+                            return getSongs().map((List<Song> songs) -> granted);
+                        }
+                    })
                     .observeOn(Schedulers.io())
                     .subscribe(granted -> {
                         if (granted) {
@@ -166,6 +173,13 @@ public class LocalMusicStore implements MusicStore {
             mArtists = BehaviorSubject.create();
 
             MediaStoreUtil.getPermission(mContext)
+                    .flatMap(granted -> {
+                        if (noDirectoryFilters()) {
+                            return Observable.just(granted);
+                        } else {
+                            return getSongs().map((List<Song> songs) -> granted);
+                        }
+                    })
                     .observeOn(Schedulers.io())
                     .subscribe(granted -> {
                         if (granted) {

--- a/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
+++ b/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
@@ -204,7 +204,7 @@ public class LocalMusicStore implements MusicStore {
         return filterGenres(MediaStoreUtil.getGenres(mContext, null, null));
     }
 
-    private boolean shouldFilterMedia() {
+    private boolean noDirectoryFilters() {
         boolean notIncludingFolders = mPreferencesStore.getIncludedDirectories().isEmpty();
         boolean notExcludingFolders = mPreferencesStore.getExcludedDirectories().isEmpty();
 
@@ -212,7 +212,7 @@ public class LocalMusicStore implements MusicStore {
     }
 
     private List<Album> filterAlbums(List<Album> albumsToFilter) {
-        if (shouldFilterMedia()) {
+        if (noDirectoryFilters()) {
             return albumsToFilter;
         }
 
@@ -231,7 +231,7 @@ public class LocalMusicStore implements MusicStore {
     }
 
     private List<Artist> filterArtists(List<Artist> artistsToFilter) {
-        if (shouldFilterMedia()) {
+        if (noDirectoryFilters()) {
             return artistsToFilter;
         }
 
@@ -250,7 +250,7 @@ public class LocalMusicStore implements MusicStore {
     }
 
     private List<Genre> filterGenres(List<Genre> genresToFilter) {
-        if (shouldFilterMedia()) {
+        if (noDirectoryFilters()) {
             return genresToFilter;
         }
 

--- a/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
+++ b/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
@@ -35,8 +35,9 @@ public class LocalMusicStore implements MusicStore {
 
     @Override
     public Observable<Boolean> refresh() {
-        return MediaStoreUtil.promptPermission(mContext).map(
-                granted -> {
+        return MediaStoreUtil.promptPermission(mContext)
+                .subscribeOn(Schedulers.io())
+                .map(granted -> {
                     if (granted) {
                         if (mSongs != null) {
                             mSongs.onNext(getAllSongs());
@@ -52,7 +53,8 @@ public class LocalMusicStore implements MusicStore {
                         }
                     }
                     return granted;
-                });
+                })
+                .observeOn(AndroidSchedulers.mainThread());
     }
 
     @Override

--- a/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
+++ b/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
@@ -211,7 +211,7 @@ public class LocalMusicStore implements MusicStore {
                         }
                     });
         }
-        return mGenres.asObservable().subscribeOn(AndroidSchedulers.mainThread());
+        return mGenres.asObservable().observeOn(AndroidSchedulers.mainThread());
     }
 
     private List<Genre> getAllGenres() {

--- a/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
+++ b/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
@@ -14,6 +14,8 @@ import java.util.Collections;
 import java.util.List;
 
 import rx.Observable;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
 
 public class LocalMusicStore implements MusicStore {
@@ -58,15 +60,17 @@ public class LocalMusicStore implements MusicStore {
         if (mSongs == null) {
             mSongs = BehaviorSubject.create();
 
-            MediaStoreUtil.getPermission(mContext).subscribe(granted -> {
-                if (granted) {
-                    mSongs.onNext(getAllSongs());
-                } else {
-                    mSongs.onNext(Collections.emptyList());
-                }
-            });
+            MediaStoreUtil.getPermission(mContext)
+                    .observeOn(Schedulers.io())
+                    .subscribe(granted -> {
+                        if (granted) {
+                            mSongs.onNext(getAllSongs());
+                        } else {
+                            mSongs.onNext(Collections.emptyList());
+                        }
+                    });
         }
-        return mSongs;
+        return mSongs.asObservable().observeOn(AndroidSchedulers.mainThread());
     }
 
     private List<Song> getAllSongs() {
@@ -137,15 +141,17 @@ public class LocalMusicStore implements MusicStore {
         if (mAlbums == null) {
             mAlbums = BehaviorSubject.create();
 
-            MediaStoreUtil.getPermission(mContext).subscribe(granted -> {
-                if (granted) {
-                    mAlbums.onNext(getAllAlbums());
-                } else {
-                    mAlbums.onNext(Collections.emptyList());
-                }
-            });
+            MediaStoreUtil.getPermission(mContext)
+                    .observeOn(Schedulers.io())
+                    .subscribe(granted -> {
+                        if (granted) {
+                            mAlbums.onNext(getAllAlbums());
+                        } else {
+                            mAlbums.onNext(Collections.emptyList());
+                        }
+                    });
         }
-        return mAlbums;
+        return mAlbums.asObservable().observeOn(AndroidSchedulers.mainThread());
     }
 
     private List<Album> getAllAlbums() {
@@ -157,15 +163,17 @@ public class LocalMusicStore implements MusicStore {
         if (mArtists == null) {
             mArtists = BehaviorSubject.create();
 
-            MediaStoreUtil.getPermission(mContext).subscribe(granted -> {
-                if (granted) {
-                    mArtists.onNext(getAllArtists());
-                } else {
-                    mArtists.onNext(Collections.emptyList());
-                }
-            });
+            MediaStoreUtil.getPermission(mContext)
+                    .observeOn(Schedulers.io())
+                    .subscribe(granted -> {
+                        if (granted) {
+                            mArtists.onNext(getAllArtists());
+                        } else {
+                            mArtists.onNext(Collections.emptyList());
+                        }
+                    });
         }
-        return mArtists;
+        return mArtists.asObservable().observeOn(AndroidSchedulers.mainThread());
     }
 
     private List<Artist> getAllArtists() {
@@ -177,15 +185,17 @@ public class LocalMusicStore implements MusicStore {
         if (mGenres == null) {
             mGenres = BehaviorSubject.create();
 
-            MediaStoreUtil.getPermission(mContext).subscribe(granted -> {
-                if (granted) {
-                    mGenres.onNext(getAllGenres());
-                } else {
-                    mGenres.onNext(Collections.emptyList());
-                }
-            });
+            MediaStoreUtil.getPermission(mContext)
+                    .observeOn(Schedulers.io())
+                    .subscribe(granted -> {
+                        if (granted) {
+                            mGenres.onNext(getAllGenres());
+                        } else {
+                            mGenres.onNext(Collections.emptyList());
+                        }
+                    });
         }
-        return mGenres;
+        return mGenres.asObservable().subscribeOn(AndroidSchedulers.mainThread());
     }
 
     private List<Genre> getAllGenres() {

--- a/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
+++ b/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
@@ -216,10 +216,6 @@ public class LocalMusicStore implements MusicStore {
             return albumsToFilter;
         }
 
-        if (mSongs == null || !mSongs.hasValue()) {
-            getSongs();
-        }
-
         List<Album> filteredAlbums = new ArrayList<>();
 
         for (Album album : albumsToFilter) {
@@ -237,10 +233,6 @@ public class LocalMusicStore implements MusicStore {
     private List<Artist> filterArtists(List<Artist> artistsToFilter) {
         if (shouldFilterMedia()) {
             return artistsToFilter;
-        }
-
-        if (mSongs == null || !mSongs.hasValue()) {
-            getSongs();
         }
 
         List<Artist> filteredArtists = new ArrayList<>();

--- a/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
+++ b/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
@@ -269,10 +269,11 @@ public class LocalMusicStore implements MusicStore {
         }
 
         List<Genre> filteredGenres = new ArrayList<>();
+        String directorySelection = getDirectoryInclusionExclusionSelection();
 
         for (Genre genre : genresToFilter) {
             boolean hasSongs = !MediaStoreUtil.getGenreSongs(mContext, genre,
-                    getDirectoryInclusionExclusionSelection(), null).isEmpty();
+                    directorySelection, null).isEmpty();
 
             if (hasSongs) {
                 filteredGenres.add(genre);

--- a/app/src/main/java/com/marverenic/music/data/store/LocalPlaylistStore.java
+++ b/app/src/main/java/com/marverenic/music/data/store/LocalPlaylistStore.java
@@ -13,6 +13,8 @@ import java.util.Collections;
 import java.util.List;
 
 import rx.Observable;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
 
 public class LocalPlaylistStore implements PlaylistStore {
@@ -26,8 +28,9 @@ public class LocalPlaylistStore implements PlaylistStore {
 
     @Override
     public Observable<Boolean> refresh() {
-        return MediaStoreUtil.promptPermission(mContext).map(
-                granted -> {
+        return MediaStoreUtil.promptPermission(mContext)
+                .subscribeOn(Schedulers.io())
+                .map(granted -> {
                     if (mPlaylists != null) {
                         mPlaylists.onNext(getAllPlaylists());
                     }
@@ -40,15 +43,17 @@ public class LocalPlaylistStore implements PlaylistStore {
         if (mPlaylists == null) {
             mPlaylists = BehaviorSubject.create();
 
-            MediaStoreUtil.getPermission(mContext).subscribe(granted -> {
-                if (granted) {
-                    mPlaylists.onNext(getAllPlaylists());
-                } else {
-                    mPlaylists.onNext(Collections.emptyList());
-                }
-            });
+            MediaStoreUtil.getPermission(mContext)
+                    .observeOn(Schedulers.io())
+                    .subscribe(granted -> {
+                        if (granted) {
+                            mPlaylists.onNext(getAllPlaylists());
+                        } else {
+                            mPlaylists.onNext(Collections.emptyList());
+                        }
+                    });
         }
-        return mPlaylists;
+        return mPlaylists.asObservable().observeOn(AndroidSchedulers.mainThread());
     }
 
     private List<Playlist> getAllPlaylists() {


### PR DESCRIPTION
Refactors MusicStore and PlaylistStore implementation to perform library loading computations in the background with RxJava. Currently, this only affects the list of all playlists, songs, artists, albums, and genres – not actions getting song group contents or finding entries by ID.