### PR TITLE
Allow the player service to be closed on Lollipop and higher while the app is running

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -243,7 +243,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             startForeground(NOTIFICATION_ID, notification);
-        } else if (!musicPlayer.isPlaying() && !mAppRunning) {
+        } else if (!musicPlayer.isPlaying()) {
             stopForeground(false);
 
             NotificationManager mgr = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);


### PR DESCRIPTION
Changes the notification behavior to be dismissable while playback is paused – dropping the requirement that the app had to be closed (i.e. not in the task stack).