### PR TITLE
Fix NPE & loading spinner incorrectly showing

### DIFF
--- a/app/src/main/java/com/marverenic/music/activity/instance/ArtistActivity.java
+++ b/app/src/main/java/com/marverenic/music/activity/instance/ArtistActivity.java
@@ -138,7 +138,10 @@ public class ArtistActivity extends BaseActivity {
                     .compose(bindToLifecycle())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(this::setLastFmReference,
-                            throwable -> Timber.e(throwable, "Failed to get Last.fm artist info"));
+                            throwable -> {
+                                Timber.e(throwable, "Failed to get Last.fm artist info");
+                                hideLoadingSpinner();
+                            });
         }
     }
 

--- a/app/src/main/java/com/marverenic/music/activity/instance/ArtistActivity.java
+++ b/app/src/main/java/com/marverenic/music/activity/instance/ArtistActivity.java
@@ -155,18 +155,20 @@ public class ArtistActivity extends BaseActivity {
         mLfmReference = lfmArtist;
         mRelatedArtists = new ArrayList<>();
 
-        for (LfmArtist relatedArtist : lfmArtist.getSimilarArtists()) {
-            mMusicStore.findArtistByName(relatedArtist.getName())
-                    .subscribe(
-                            found -> {
-                                if (found != null) {
-                                    mRelatedArtists.add(relatedArtist);
-                                    setupAdapter();
-                                }
-                            },
-                            throwable -> {
-                                Timber.e(throwable, "Failed to find artist");
-                            });
+        if (lfmArtist.getSimilarArtists() != null) {
+            for (LfmArtist relatedArtist : lfmArtist.getSimilarArtists()) {
+                mMusicStore.findArtistByName(relatedArtist.getName())
+                        .subscribe(
+                                found -> {
+                                    if (found != null) {
+                                        mRelatedArtists.add(relatedArtist);
+                                        setupAdapter();
+                                    }
+                                },
+                                throwable -> {
+                                    Timber.e(throwable, "Failed to find artist");
+                                });
+            }
         }
         setupAdapter();
 

--- a/app/src/main/java/com/marverenic/music/activity/instance/ArtistActivity.java
+++ b/app/src/main/java/com/marverenic/music/activity/instance/ArtistActivity.java
@@ -155,20 +155,18 @@ public class ArtistActivity extends BaseActivity {
         mLfmReference = lfmArtist;
         mRelatedArtists = new ArrayList<>();
 
-        if (lfmArtist.getSimilarArtists() != null) {
-            for (LfmArtist relatedArtist : lfmArtist.getSimilarArtists()) {
-                mMusicStore.findArtistByName(relatedArtist.getName())
-                        .subscribe(
-                                found -> {
-                                    if (found != null) {
-                                        mRelatedArtists.add(relatedArtist);
-                                        setupAdapter();
-                                    }
-                                },
-                                throwable -> {
-                                    Timber.e(throwable, "Failed to find artist");
-                                });
-            }
+        for (LfmArtist relatedArtist : lfmArtist.getSimilarArtists()) {
+            mMusicStore.findArtistByName(relatedArtist.getName())
+                    .subscribe(
+                            found -> {
+                                if (found != null) {
+                                    mRelatedArtists.add(relatedArtist);
+                                    setupAdapter();
+                                }
+                            },
+                            throwable -> {
+                                Timber.e(throwable, "Failed to find artist");
+                            });
         }
         setupAdapter();
 

--- a/app/src/main/java/com/marverenic/music/activity/instance/ArtistActivity.java
+++ b/app/src/main/java/com/marverenic/music/activity/instance/ArtistActivity.java
@@ -152,6 +152,11 @@ public class ArtistActivity extends BaseActivity {
     }
 
     private void setLastFmReference(LfmArtist lfmArtist) {
+        if (lfmArtist == null) {
+            hideLoadingSpinner();
+            return;
+        }
+
         mLfmReference = lfmArtist;
         mRelatedArtists = new ArrayList<>();
 
@@ -277,10 +282,7 @@ public class ArtistActivity extends BaseActivity {
             return;
         }
 
-        if (mLoadingSection != null) {
-            mAdapter.removeSection(0);
-            mLoadingSection = null;
-        }
+        hideLoadingSpinner();
 
         if (mBioSection == null) {
             mBioSection = new ArtistBioSingleton(mLfmReference, !mRelatedArtists.isEmpty());
@@ -294,6 +296,13 @@ public class ArtistActivity extends BaseActivity {
                     new GridSpacingDecoration(
                             (int) getResources().getDimension(R.dimen.card_margin),
                             mColumnCount, mRelatedArtistSection.getTypeId()));
+        }
+    }
+
+    private void hideLoadingSpinner() {
+        if (mLoadingSection != null) {
+            mAdapter.removeSection(0);
+            mLoadingSection = null;
         }
     }
 


### PR DESCRIPTION
Resolves an issue where the loading spinner would continue to display after an artist failed to load (either because it is not in the Last.fm database, or because a network error occurred), as well as a non-fatal NPE.

**Reproduction Steps:**
 - Open the artist page for an artist not in the Last.fm database
 - The loading spinner will never disappear

Also:
 - Open an artist page while connected to a network with no internet access
 - The loading spinner will never disappear

**Expected behavior:**
 - If the artist is not in Last.fm, or there is an error loading the data, the loading spinner should disappear.