### PR TITLE
Persist DurationPickerDialog state across rotations

### DIFF
--- a/app/src/main/java/com/marverenic/music/dialog/DurationPickerDialogFragment.java
+++ b/app/src/main/java/com/marverenic/music/dialog/DurationPickerDialogFragment.java
@@ -48,6 +48,12 @@ public class DurationPickerDialogFragment extends DialogFragment
         }
     }
 
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt(KEY_SAVED_VAL, mOffsetValue);
+    }
+
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {


### PR DESCRIPTION
This fixes an issue where recreating a DurationPickerDialogFragment would not persist the previously selected duration and would reset to 0.