### PR TITLE
Fix shuffled and non-shuffled queues becoming out of sync

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -604,12 +604,12 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
         List<Song> unshuffled = new ArrayList<>(mQueue);
         List<Song> songs = new ArrayList<>(mQueueShuffled);
 
-        // TODO make this not O(n^2)
-        for (Iterator<Song> it = unshuffled.iterator(); it.hasNext(); ) {
-            Song song = it.next();
+        Iterator<Song> unshuffledIterator = unshuffled.iterator();
+        while (unshuffledIterator.hasNext()) {
+            Song song = unshuffledIterator.next();
 
             if (!songs.remove(song)) {
-                it.remove();
+                unshuffledIterator.remove();
             }
         }
 

--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -37,6 +37,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Scanner;
@@ -599,6 +600,22 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
         }
     }
 
+    private void unshuffleQueue() {
+        List<Song> unshuffled = new ArrayList<>(mQueue);
+        List<Song> songs = new ArrayList<>(mQueueShuffled);
+
+        // TODO make this not O(n^2)
+        for (Iterator<Song> it = unshuffled.iterator(); it.hasNext(); ) {
+            Song song = it.next();
+
+            if (!songs.remove(song)) {
+                it.remove();
+            }
+        }
+
+        mQueue = unshuffled;
+    }
+
     /**
      * Prepares the backing {@link QueuedMediaPlayer} for playback
      * @param playWhenReady Whether playback will begin when the current song has been prepared
@@ -969,7 +986,8 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
             mMediaPlayer.setQueue(mQueueShuffled, 0);
         } else {
             Timber.i("Disabling shuffle...");
-            int position = mQueue.indexOf(mQueueShuffled.get(mMediaPlayer.getQueueIndex()));
+            unshuffleQueue();
+            int position = mQueue.indexOf(getNowPlaying());
             mMediaPlayer.setQueue(mQueue, position);
         }
         mShuffle = shuffle;


### PR DESCRIPTION
Resolves an issue where removing a song from the queue when shuffle is enabled would keep the song in the queue after disabling shuffle.