### PR TITLE
Fix seekbar on now playing page becomming incorrectly disabled

### DIFF
--- a/app/src/main/java/com/marverenic/music/viewmodel/NowPlayingControllerViewModel.java
+++ b/app/src/main/java/com/marverenic/music/viewmodel/NowPlayingControllerViewModel.java
@@ -81,6 +81,7 @@ public class NowPlayingControllerViewModel extends BaseObservable {
         notifyPropertyChanged(BR.albumName);
         notifyPropertyChanged(BR.songDuration);
         notifyPropertyChanged(BR.positionVisibility);
+        notifyPropertyChanged(BR.seekbarEnabled);
     }
 
     public void setPlaying(boolean playing) {


### PR DESCRIPTION
Reproduction steps:
 - Play a song in Jockey
 - Run `adb shell am stopservice com.marverenic.music.debug/com.marverenic.music.player.PlayerService` in a terminal
 - Open the now playing page

Expected Behavior:
 - When the service restarts, the seekbar will be enabled