### PR TITLE
Replace apt with annotationProcessor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'io.fabric'
 
@@ -77,8 +76,7 @@ dependencies {
     compile 'com.h6ah4i.android.widget.verticalseekbar:verticalseekbar:0.5.2'
 
     compile 'com.google.dagger:dagger:2.6'
-    apt 'com.google.dagger:dagger-compiler:2.6'
-    apt 'com.google.guava:guava:19.0'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.6'
 
     compile 'io.reactivex:rxjava:1.1.6'
     compile 'io.reactivex:rxandroid:1.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
     //noinspection GroovyAssignabilityCheck
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'me.tatarka:gradle-retrolambda:3.2.5'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
As of version 2.2 of the gradle build tools, annotation proccessors are supported in gradle without the need for android-apt