### PR TITLE
Fix scrolling behavior on now playing queue

### DIFF
--- a/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
+++ b/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
@@ -101,7 +101,7 @@ public class QueueFragment extends Fragment implements PlayerController.UpdateLi
                     return "";
                 }
             });
-        } else {
+        } else if (!mQueueSection.getData().equals(PlayerController.getQueue())) {
             mQueueSection.setData(PlayerController.getQueue());
             mAdapter.notifyDataSetChanged();
         }

--- a/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
+++ b/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
@@ -141,7 +141,7 @@ public class QueueFragment extends Fragment implements PlayerController.UpdateLi
         }
 
         mAdapter.notifyDataSetChanged();
-        scrollToNowPlaying();
+        smoothScrollToNowPlaying();
     }
 
     private void setupRecyclerView() {
@@ -196,7 +196,7 @@ public class QueueFragment extends Fragment implements PlayerController.UpdateLi
             mAdapter.notifyItemChanged(currentIndex);
 
             if (shouldScrollToCurrent()) {
-                scrollToNowPlaying();
+                smoothScrollToNowPlaying();
             }
         }
     }
@@ -220,7 +220,7 @@ public class QueueFragment extends Fragment implements PlayerController.UpdateLi
                 || (bottomIndex - queueSize <= 2 && lastPlayIndex == queueSize - 1);
     }
 
-    private void scrollToNowPlaying() {
+    private void updateSpacers() {
         if (mBottomSpacers == null) {
             return;
         }
@@ -245,9 +245,20 @@ public class QueueFragment extends Fragment implements PlayerController.UpdateLi
             int removedSpacers = prevVisibleSpacers - visibleSpacers;
             mAdapter.notifyItemRangeRemoved(firstSpacerIndex, removedSpacers);
         }
+    }
+
+    private void smoothScrollToNowPlaying() {
+        updateSpacers();
 
         mScroller.setTargetPosition(lastPlayIndex);
         mRecyclerView.getLayoutManager().startSmoothScroll(mScroller);
+    }
+
+    private void scrollToNowPlaying() {
+        updateSpacers();
+
+        ((LinearLayoutManager) mRecyclerView.getLayoutManager())
+                .scrollToPositionWithOffset(lastPlayIndex, 0);
     }
 
     public void updateShuffle() {

--- a/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
+++ b/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
@@ -13,6 +13,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.marverenic.heterogeneousadapter.DragDropAdapter;
+import com.marverenic.heterogeneousadapter.DragDropDecoration;
 import com.marverenic.music.R;
 import com.marverenic.music.instances.section.LibraryEmptyState;
 import com.marverenic.music.instances.section.QueueSection;
@@ -20,9 +22,8 @@ import com.marverenic.music.instances.section.SpacerSingleton;
 import com.marverenic.music.player.PlayerController;
 import com.marverenic.music.view.DragBackgroundDecoration;
 import com.marverenic.music.view.DragDividerDecoration;
-import com.marverenic.heterogeneousadapter.DragDropAdapter;
-import com.marverenic.heterogeneousadapter.DragDropDecoration;
 import com.marverenic.music.view.InsetDecoration;
+import com.marverenic.music.view.QueueAnimator;
 import com.marverenic.music.view.SnappingScroller;
 
 import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
@@ -75,6 +76,7 @@ public class QueueFragment extends Fragment implements PlayerController.UpdateLi
         if (mQueueSection == null) {
             mAdapter = new DragDropAdapter();
             mAdapter.attach(mRecyclerView);
+            mRecyclerView.setItemAnimator(new QueueAnimator());
 
             mQueueSection = new QueueSection(this, PlayerController.getQueue());
 

--- a/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
+++ b/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
@@ -23,6 +23,7 @@ import com.marverenic.music.view.DragDividerDecoration;
 import com.marverenic.heterogeneousadapter.DragDropAdapter;
 import com.marverenic.heterogeneousadapter.DragDropDecoration;
 import com.marverenic.music.view.InsetDecoration;
+import com.marverenic.music.view.SnappingScroller;
 
 import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
 
@@ -35,12 +36,15 @@ public class QueueFragment extends Fragment implements PlayerController.UpdateLi
     private QueueSection mQueueSection;
     private SpacerSingleton[] mBottomSpacers;
 
+    private SnappingScroller mScroller;
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
 
         View view = inflater.inflate(R.layout.list, container, false);
         mRecyclerView = (RecyclerView) view.findViewById(R.id.list);
+        mScroller = new SnappingScroller(getContext(), SnappingScroller.SNAP_TO_START);
 
         setupAdapter();
         setupRecyclerView();
@@ -240,8 +244,8 @@ public class QueueFragment extends Fragment implements PlayerController.UpdateLi
             mAdapter.notifyItemRangeRemoved(firstSpacerIndex, removedSpacers);
         }
 
-        ((LinearLayoutManager) mRecyclerView.getLayoutManager())
-                .scrollToPositionWithOffset(lastPlayIndex, 0);
+        mScroller.setTargetPosition(lastPlayIndex);
+        mRecyclerView.getLayoutManager().startSmoothScroll(mScroller);
     }
 
     public void updateShuffle() {

--- a/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
+++ b/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
@@ -37,15 +37,12 @@ public class QueueFragment extends Fragment implements PlayerController.UpdateLi
     private QueueSection mQueueSection;
     private SpacerSingleton[] mBottomSpacers;
 
-    private SnappingScroller mScroller;
-
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
 
         View view = inflater.inflate(R.layout.list, container, false);
         mRecyclerView = (RecyclerView) view.findViewById(R.id.list);
-        mScroller = new SnappingScroller(getContext(), SnappingScroller.SNAP_TO_START);
 
         setupAdapter();
         setupRecyclerView();
@@ -250,8 +247,10 @@ public class QueueFragment extends Fragment implements PlayerController.UpdateLi
     private void smoothScrollToNowPlaying() {
         updateSpacers();
 
-        mScroller.setTargetPosition(lastPlayIndex);
-        mRecyclerView.getLayoutManager().startSmoothScroll(mScroller);
+        RecyclerView.SmoothScroller scroller =
+                new SnappingScroller(getContext(), SnappingScroller.SNAP_TO_START);
+        scroller.setTargetPosition(lastPlayIndex);
+        mRecyclerView.getLayoutManager().startSmoothScroll(scroller);
     }
 
     private void scrollToNowPlaying() {

--- a/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
+++ b/app/src/main/java/com/marverenic/music/fragments/QueueFragment.java
@@ -75,11 +75,11 @@ public class QueueFragment extends Fragment implements PlayerController.UpdateLi
     private void setupAdapter() {
         if (mQueueSection == null) {
             mAdapter = new DragDropAdapter();
+            mAdapter.setHasStableIds(true);
             mAdapter.attach(mRecyclerView);
+
             mRecyclerView.setItemAnimator(new QueueAnimator());
-
             mQueueSection = new QueueSection(this, PlayerController.getQueue());
-
             mAdapter.setDragSection(mQueueSection);
 
             // Wait for a layout pass before calculating bottom spacing since it is dependent on the

--- a/app/src/main/java/com/marverenic/music/instances/section/EditableSongSection.java
+++ b/app/src/main/java/com/marverenic/music/instances/section/EditableSongSection.java
@@ -1,25 +1,46 @@
 package com.marverenic.music.instances.section;
 
+import android.support.v4.util.ArrayMap;
 import android.view.ViewGroup;
 
-import com.marverenic.music.R;
-import com.marverenic.music.instances.Song;
 import com.marverenic.heterogeneousadapter.DragDropAdapter;
 import com.marverenic.heterogeneousadapter.EnhancedViewHolder;
 import com.marverenic.heterogeneousadapter.HeterogeneousAdapter;
+import com.marverenic.music.R;
+import com.marverenic.music.instances.Song;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public abstract class EditableSongSection extends DragDropAdapter.DragSection<Song> {
 
     protected List<Song> mData;
+    private final List<Integer> mIds;
 
     public EditableSongSection(List<Song> data) {
-        mData = data;
+        mIds = new ArrayList<>();
+        setData(data);
     }
 
     public void setData(List<Song> data) {
         mData = data;
+        buildIdMap();
+    }
+
+    private void buildIdMap() {
+        mIds.clear();
+        Map<Song, Integer> occurrences = new ArrayMap<>();
+        for (Song song : mData) {
+            Integer count = occurrences.get(song);
+            if (count == null) {
+                count = 0;
+            }
+
+            int id = (int) (song.getSongId() * Math.pow(7, count));
+            mIds.add(id);
+            occurrences.put(song, ++count);
+        }
     }
 
     public List<Song> getData() {
@@ -28,7 +49,7 @@ public abstract class EditableSongSection extends DragDropAdapter.DragSection<So
 
     @Override
     public int getId(int position) {
-        return (int) get(position).getSongId();
+        return mIds.get(position);
     }
 
     @Override
@@ -46,6 +67,12 @@ public abstract class EditableSongSection extends DragDropAdapter.DragSection<So
 
         mData.set(to, fromObject);
         mData.set(from, toObject);
+
+        Integer fromId = mIds.get(from);
+        Integer toId = mIds.get(to);
+
+        mIds.set(to, fromId);
+        mIds.set(from, toId);
     }
 
     @Override

--- a/app/src/main/java/com/marverenic/music/instances/section/QueueSection.java
+++ b/app/src/main/java/com/marverenic/music/instances/section/QueueSection.java
@@ -66,7 +66,6 @@ public class QueueSection extends EditableSongSection {
     public class ViewHolder extends EnhancedViewHolder<Song> {
 
         private InstanceSongQueueBinding mBinding;
-        private boolean mRemoved;
 
         public ViewHolder(InstanceSongQueueBinding binding, List<Song> songList,
                           HeterogeneousAdapter adapter) {
@@ -74,22 +73,12 @@ public class QueueSection extends EditableSongSection {
             mBinding = binding;
 
             binding.setViewModel(new QueueSongViewModel(itemView.getContext(), mFragmentManager,
-                    songList, () -> onRemove(adapter)));
-        }
-
-        private void onRemove(HeterogeneousAdapter adapter) {
-            mRemoved = true;
-            adapter.notifyDataSetChanged();
-        }
-
-        public boolean isRemoved() {
-            return mRemoved;
+                    songList, adapter::notifyDataSetChanged));
         }
 
         @Override
         public void onUpdate(Song s, int sectionPosition) {
             mBinding.getViewModel().setSong(getData(), sectionPosition);
-            mRemoved = false;
         }
     }
 }

--- a/app/src/main/java/com/marverenic/music/instances/section/QueueSection.java
+++ b/app/src/main/java/com/marverenic/music/instances/section/QueueSection.java
@@ -63,9 +63,10 @@ public class QueueSection extends EditableSongSection {
         return new ViewHolder(binding, getData(), adapter);
     }
 
-    private class ViewHolder extends EnhancedViewHolder<Song> {
+    public class ViewHolder extends EnhancedViewHolder<Song> {
 
         private InstanceSongQueueBinding mBinding;
+        private boolean mRemoved;
 
         public ViewHolder(InstanceSongQueueBinding binding, List<Song> songList,
                           HeterogeneousAdapter adapter) {
@@ -73,12 +74,22 @@ public class QueueSection extends EditableSongSection {
             mBinding = binding;
 
             binding.setViewModel(new QueueSongViewModel(itemView.getContext(), mFragmentManager,
-                    songList, adapter::notifyDataSetChanged));
+                    songList, () -> onRemove(adapter)));
+        }
+
+        private void onRemove(HeterogeneousAdapter adapter) {
+            mRemoved = true;
+            adapter.notifyDataSetChanged();
+        }
+
+        public boolean isRemoved() {
+            return mRemoved;
         }
 
         @Override
         public void onUpdate(Song s, int sectionPosition) {
             mBinding.getViewModel().setSong(getData(), sectionPosition);
+            mRemoved = false;
         }
     }
 }

--- a/app/src/main/java/com/marverenic/music/instances/section/SpacerSingleton.java
+++ b/app/src/main/java/com/marverenic/music/instances/section/SpacerSingleton.java
@@ -11,21 +11,26 @@ import com.marverenic.heterogeneousadapter.HeterogeneousAdapter;
 
 public class SpacerSingleton extends HeterogeneousAdapter.SingletonSection<Void> {
 
-    private int mHeight;
+    private final int mHeight;
+    private boolean mVisible;
 
     public SpacerSingleton(int height) {
         super(null);
         mHeight = height;
+        mVisible = true;
     }
 
-    public void setHeight(int height) {
-        mHeight = height;
+    public void setShowSection(boolean visible) {
+        mVisible = visible;
+    }
+
+    public boolean showSection() {
+        return mVisible;
     }
 
     @Override
     public boolean showSection(HeterogeneousAdapter adapter) {
-        int thisIndex = adapter.getSectionIndex(this);
-        return adapter.getSection(thisIndex - 1).getItemCount(adapter) > 0;
+        return mVisible;
     }
 
     @Override

--- a/app/src/main/java/com/marverenic/music/player/PlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerController.java
@@ -356,6 +356,7 @@ public final class PlayerController {
         if (playerService != null) {
             try {
                 playerService.editQueue(queue, queuePosition);
+                updateUi();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to edit queue");
             }

--- a/app/src/main/java/com/marverenic/music/view/DragBackgroundDecoration.java
+++ b/app/src/main/java/com/marverenic/music/view/DragBackgroundDecoration.java
@@ -121,10 +121,17 @@ public class DragBackgroundDecoration extends RecyclerView.ItemDecoration {
 
         // If the last item in the list is being moved, make sure to draw the
         // background to fill the view
-        View lastView = parent.getChildAt(parent.getChildCount() - 1);
-        if (sectionCount == 0 || mRectPool.get(sectionCount - 1).bottom + lastView.getHeight()
-                < parent.getBottom()) {
-            addRect(sectionCount, left, lastView.getBottom(), right, parent.getBottom());
+        View lastView = null;
+        for (int i = parent.getChildCount() - 1; lastView == null && i >= 0; i--) {
+            View view = parent.getChildAt(i);
+            if (parent.getChildLayoutPosition(view) != RecyclerView.NO_POSITION) {
+                lastView = view;
+            }
+        }
+
+        if (lastView != null && (sectionCount == 0 || mRectPool.get(sectionCount - 1).bottom
+                + lastView.getHeight() < parent.getBottom())) {
+            addRect(sectionCount, left, lastView.getTop(), right, parent.getHeight());
             sectionCount++;
         }
 

--- a/app/src/main/java/com/marverenic/music/view/QueueAnimator.java
+++ b/app/src/main/java/com/marverenic/music/view/QueueAnimator.java
@@ -1,0 +1,52 @@
+package com.marverenic.music.view;
+
+import android.support.v7.widget.DefaultItemAnimator;
+import android.support.v7.widget.RecyclerView;
+
+import com.marverenic.music.instances.section.QueueSection;
+import com.marverenic.music.instances.section.SpacerSingleton;
+
+public class QueueAnimator extends DefaultItemAnimator {
+
+    public QueueAnimator() {
+        setSupportsChangeAnimations(false);
+    }
+
+    @Override
+    public boolean animateAdd(RecyclerView.ViewHolder holder) {
+        if (shouldAnimateAdd(holder)) {
+            return super.animateAdd(holder);
+        } else {
+            dispatchAddFinished(holder);
+            return false;
+        }
+    }
+
+    private boolean shouldAnimateAdd(RecyclerView.ViewHolder holder) {
+        if (holder instanceof SpacerSingleton.ViewHolder) {
+            return false;
+        } else if (holder instanceof QueueSection.ViewHolder) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean animateRemove(RecyclerView.ViewHolder holder) {
+        if (shouldAnimateRemove(holder)) {
+            return super.animateRemove(holder);
+        } else {
+            dispatchRemoveFinished(holder);
+            return false;
+        }
+    }
+
+    private boolean shouldAnimateRemove(RecyclerView.ViewHolder holder) {
+        if (holder instanceof SpacerSingleton.ViewHolder) {
+            return true;
+        } else if (holder instanceof QueueSection.ViewHolder) {
+            return ((QueueSection.ViewHolder) holder).isRemoved();
+        }
+        return true;
+    }
+}

--- a/app/src/main/java/com/marverenic/music/view/QueueAnimator.java
+++ b/app/src/main/java/com/marverenic/music/view/QueueAnimator.java
@@ -1,7 +1,7 @@
 package com.marverenic.music.view;
 
 import android.support.v7.widget.DefaultItemAnimator;
-import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.RecyclerView.ViewHolder;
 
 import com.marverenic.music.instances.section.QueueSection;
 import com.marverenic.music.instances.section.SpacerSingleton;
@@ -13,7 +13,7 @@ public class QueueAnimator extends DefaultItemAnimator {
     }
 
     @Override
-    public boolean animateAdd(RecyclerView.ViewHolder holder) {
+    public boolean animateAdd(ViewHolder holder) {
         if (shouldAnimateAdd(holder)) {
             return super.animateAdd(holder);
         } else {
@@ -22,17 +22,17 @@ public class QueueAnimator extends DefaultItemAnimator {
         }
     }
 
-    private boolean shouldAnimateAdd(RecyclerView.ViewHolder holder) {
+    private boolean shouldAnimateAdd(ViewHolder holder) {
         if (holder instanceof SpacerSingleton.ViewHolder) {
             return false;
         } else if (holder instanceof QueueSection.ViewHolder) {
-            return false;
+            return true;
         }
-        return true;
+        return false;
     }
 
     @Override
-    public boolean animateRemove(RecyclerView.ViewHolder holder) {
+    public boolean animateRemove(ViewHolder holder) {
         if (shouldAnimateRemove(holder)) {
             return super.animateRemove(holder);
         } else {
@@ -41,11 +41,11 @@ public class QueueAnimator extends DefaultItemAnimator {
         }
     }
 
-    private boolean shouldAnimateRemove(RecyclerView.ViewHolder holder) {
+    private boolean shouldAnimateRemove(ViewHolder holder) {
         if (holder instanceof SpacerSingleton.ViewHolder) {
-            return true;
+            return false;
         } else if (holder instanceof QueueSection.ViewHolder) {
-            return ((QueueSection.ViewHolder) holder).isRemoved();
+            return true;
         }
         return true;
     }

--- a/app/src/main/java/com/marverenic/music/view/SnappingScroller.java
+++ b/app/src/main/java/com/marverenic/music/view/SnappingScroller.java
@@ -1,0 +1,41 @@
+package com.marverenic.music.view;
+
+import android.content.Context;
+import android.support.v7.widget.LinearSmoothScroller;
+import android.util.DisplayMetrics;
+
+public class SnappingScroller extends LinearSmoothScroller {
+
+    private static final int MIN_SCROLL_TIME_MS = 75;
+    private static final float MILLISECONDS_PER_INCH = 50f;
+
+    public static final int SNAP_TO_START = LinearSmoothScroller.SNAP_TO_START;
+    public static final int SNAP_TO_END = LinearSmoothScroller.SNAP_TO_END;
+
+    private int mSnapPreference;
+
+    public SnappingScroller(Context context, int snap) {
+        super(context);
+        mSnapPreference = snap;
+    }
+
+    @Override
+    protected int getHorizontalSnapPreference() {
+        return mSnapPreference;
+    }
+
+    @Override
+    protected int getVerticalSnapPreference() {
+        return mSnapPreference;
+    }
+
+    @Override
+    protected float calculateSpeedPerPixel(DisplayMetrics displayMetrics) {
+        return MILLISECONDS_PER_INCH / displayMetrics.densityDpi;
+    }
+
+    @Override
+    protected int calculateTimeForScrolling(int dx) {
+        return Math.max(MIN_SCROLL_TIME_MS, super.calculateTimeForScrolling(dx));
+    }
+}


### PR DESCRIPTION
Resolves numerous defects related to the queue list on the now playing page including:
 - After upgrading the RecyclerView support library, the current track is never scrolled to when the song changes
 - Skipping to the next song may incorrectly trigger the removal animation
 - Skipping to the previous song may incorrectly trigger the add animation