### PR TITLE
Fix up button behavior on the now playing page

### DIFF
--- a/app/src/main/java/com/marverenic/music/activity/NowPlayingActivity.java
+++ b/app/src/main/java/com/marverenic/music/activity/NowPlayingActivity.java
@@ -278,6 +278,9 @@ public class NowPlayingActivity extends BaseActivity implements GestureView.OnGe
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
+            case android.R.id.home:
+                navigateUp();
+                return true;
             case R.id.action_shuffle:
                 toggleShuffle();
                 return true;
@@ -298,6 +301,14 @@ public class NowPlayingActivity extends BaseActivity implements GestureView.OnGe
                 return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void navigateUp() {
+        if (isTaskRoot()) {
+            Intent libraryIntent = new Intent(this, LibraryActivity.class);
+            startActivity(libraryIntent);
+        }
+        finish();
     }
 
     private void toggleShuffle() {


### PR DESCRIPTION
When the now playing activity is orphaned on the back stack (i.e. was opened from the notification when none of Jockey's activities are in the background) the up button now navigates to the library activity (this does not affect back button behavior, which will still just pop the back stack).