### PR TITLE
Defer queue updates until the current song finishes

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -683,7 +683,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @param skip Whether the song was skipped (true if skipped, false if played)
      */
     private void logPlayCount(Song song, boolean skip) {
-        Timber.i("Logging %s count to PlayCountStore...", (skip) ? "skip" : "play");
+        Timber.i("Logging %s count to PlayCountStore for %s...", (skip) ? "skip" : "play", song.toString());
         if (skip) {
             mPlayCountStore.incrementSkipCount(song);
         } else {


### PR DESCRIPTION
Whenever there is an update to the queue (i.e. reordered/added/deleted items, or changes to shuffle and repeat settings) the ExoPlayer timeline has to be rebuilt. This takes time, and would cause an audible gap in playback if it is done immediately. To avoid this, the preparation step is deferred until there is already going to be a gap in playback (i.e. when music is played, paused, seeked through, skipped, or finished). This will temporarily prevent gapless playback if the user edits the queue, but shouldn't be noticeable in practice since most users won't be constantly altering the queue.