### PR TITLE
Fix incorrect playback after changing the queue

### DIFF
--- a/app/src/main/aidl/com/marverenic/music/IPlayerService.aidl
+++ b/app/src/main/aidl/com/marverenic/music/IPlayerService.aidl
@@ -10,7 +10,6 @@ interface IPlayerService {
     void stop();
     void skip();
     void previous();
-    void begin();
     void togglePlay();
     void play();
     void pause();

--- a/app/src/main/java/com/marverenic/music/activity/NowPlayingActivity.java
+++ b/app/src/main/java/com/marverenic/music/activity/NowPlayingActivity.java
@@ -174,7 +174,7 @@ public class NowPlayingActivity extends BaseActivity implements GestureView.OnGe
             } else {
                 if (PlayerController.isServiceStarted()) {
                     PlayerController.setQueue(queue, position);
-                    PlayerController.begin();
+                    PlayerController.play();
                 } else {
                     // If the service hasn't been bound yet, then we need to wait for the service to
                     // start before we can pass data to it. This code will bind a short-lived
@@ -189,7 +189,7 @@ public class NowPlayingActivity extends BaseActivity implements GestureView.OnGe
                         @Override
                         public void onReceive(Context context, Intent intent) {
                             PlayerController.setQueue(pendingQueue, pendingPosition);
-                            PlayerController.begin();
+                            PlayerController.play();
                             NowPlayingActivity.this.unregisterReceiver(this);
                         }
                     };
@@ -501,7 +501,7 @@ public class NowPlayingActivity extends BaseActivity implements GestureView.OnGe
                     PlayerController.seek(previousSeekPosition);
 
                     if (wasPlaying) {
-                        PlayerController.begin();
+                        PlayerController.play();
                     }
                 })
                 .show();

--- a/app/src/main/java/com/marverenic/music/activity/SearchActivity.java
+++ b/app/src/main/java/com/marverenic/music/activity/SearchActivity.java
@@ -329,7 +329,7 @@ public class SearchActivity extends BaseActivity implements SearchView.OnQueryTe
     private void playSongResults() {
         if (!getSongResults().isEmpty()) {
             PlayerController.setQueue(getSongResults(), 0);
-            PlayerController.begin();
+            PlayerController.play();
         }
     }
 
@@ -351,7 +351,7 @@ public class SearchActivity extends BaseActivity implements SearchView.OnQueryTe
         mPlaylistStore.getSongs(playlist).subscribe(
                 songs -> {
                     PlayerController.setQueue(songs, 0);
-                    PlayerController.begin();
+                    PlayerController.play();
                 }, throwable -> {
                     Timber.e(throwable, "Failed to play playlist from intent");
                 });
@@ -376,7 +376,7 @@ public class SearchActivity extends BaseActivity implements SearchView.OnQueryTe
         combinedSongs.subscribe(
                 songs -> {
                     PlayerController.setQueue(songs, 0);
-                    PlayerController.begin();
+                    PlayerController.play();
                 },
                 throwable -> {
                     Timber.e(throwable, "Failed to play artist from intent");
@@ -401,7 +401,7 @@ public class SearchActivity extends BaseActivity implements SearchView.OnQueryTe
         mMusicStore.getSongs(album).subscribe(
                 songs -> {
                     PlayerController.setQueue(songs, 0);
-                    PlayerController.begin();
+                    PlayerController.play();
                 }, throwable -> {
                     Timber.e(throwable, "Failed to play album from intent");
                 });
@@ -424,7 +424,7 @@ public class SearchActivity extends BaseActivity implements SearchView.OnQueryTe
         mMusicStore.getSongs(genre).subscribe(
                 songs -> {
                     PlayerController.setQueue(songs, 0);
-                    PlayerController.begin();
+                    PlayerController.play();
                 }, throwable -> {
                     Timber.e(throwable, "Failed to play genre from intent");
                 });

--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -550,13 +550,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      */
     private void shuffleQueue(int currentIndex) {
         Timber.i("Shuffling queue...");
-
-        if (mQueueShuffled == null) {
-            mQueueShuffled = new ArrayList<>(mQueue);
-        } else {
-            mQueueShuffled.clear();
-            mQueueShuffled.addAll(mQueue);
-        }
+        mQueueShuffled = new ArrayList<>(mQueue);
 
         if (!mQueueShuffled.isEmpty()) {
             Song first = mQueueShuffled.remove(currentIndex);

--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -833,6 +833,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
             Timber.i("Setting new backing queue (starting at index %d)", index);
             setBackingQueue(index);
         }
+        seekTo(0);
     }
 
     /**

--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -583,16 +583,6 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
     }
 
     /**
-     * Prepares the backing {@link QueuedMediaPlayer} for playback
-     * @param playWhenReady Whether playback will begin when the current song has been prepared
-     * @see QueuedMediaPlayer#prepare(boolean)
-     */
-    public void prepare(boolean playWhenReady) {
-        Timber.i("Preparing current song...");
-        mMediaPlayer.prepare(playWhenReady && getFocus());
-    }
-
-    /**
      * Toggles playback between playing and paused states
      * @see #play()
      * @see #pause()
@@ -810,7 +800,6 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
     public void changeSong(int position) {
         Timber.i("changeSong called (position = %d)", position);
         mMediaPlayer.setQueueIndex(position);
-        prepare(true);
     }
 
     /**

--- a/app/src/main/java/com/marverenic/music/player/PlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerController.java
@@ -227,14 +227,6 @@ public final class PlayerController {
     }
 
     /**
-     * Begin playback of a new song
-     * See {@link MusicPlayer#prepare(boolean)}
-     */
-    public static void begin() {
-        play();
-    }
-
-    /**
      * Toggle between play and pause states.
      * See {@link MusicPlayer#togglePlay()}
      */

--- a/app/src/main/java/com/marverenic/music/player/PlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerController.java
@@ -231,15 +231,7 @@ public final class PlayerController {
      * See {@link MusicPlayer#prepare(boolean)}
      */
     public static void begin() {
-        if (playerService != null) {
-            try {
-                playerService.begin();
-                artwork = null;
-                updateUi();
-            } catch (RemoteException exception) {
-                Timber.e(exception, "Failed to begin playback");
-            }
-        }
+        play();
     }
 
     /**

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -330,16 +330,6 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void begin() throws RemoteException {
-            try {
-                instance.musicPlayer.prepare(true);
-            } catch (RuntimeException exception) {
-                Timber.e(exception, "Remote call to PlayerService.begin() failed");
-                throw exception;
-            }
-        }
-
-        @Override
         public void togglePlay() throws RemoteException {
             try {
                 instance.musicPlayer.togglePlay();

--- a/app/src/main/java/com/marverenic/music/player/QueuedExoPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/QueuedExoPlayer.java
@@ -186,15 +186,6 @@ public class QueuedExoPlayer implements QueuedMediaPlayer {
     }
 
     @Override
-    public void setQueue(@NonNull List<Song> queue) {
-        if (queue.size() >= mQueue.size()) {
-            setQueue(queue, mQueueIndex);
-        } else {
-            setQueue(queue, 0);
-        }
-    }
-
-    @Override
     public void setQueue(@NonNull List<Song> queue, int index) {
         if (index < 0 || (index >= queue.size() && !queue.isEmpty())) {
             throw new IllegalArgumentException("index must between 0 and queue.size");

--- a/app/src/main/java/com/marverenic/music/player/QueuedExoPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/QueuedExoPlayer.java
@@ -227,12 +227,6 @@ public class QueuedExoPlayer implements QueuedMediaPlayer {
         return mQueueIndex;
     }
 
-    @Override
-    public void prepare(boolean playWhenReady) {
-        mExoPlayer.seekTo(0);
-        mExoPlayer.setPlayWhenReady(playWhenReady);
-    }
-
     private void prepare(boolean playWhenReady, boolean resetPosition) {
         mInvalid = false;
 

--- a/app/src/main/java/com/marverenic/music/player/QueuedMediaPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/QueuedMediaPlayer.java
@@ -24,8 +24,6 @@ public interface QueuedMediaPlayer {
 
     int getQueueIndex();
 
-    void prepare(boolean playWhenReady);
-
     void skip();
 
     void skipPrevious();

--- a/app/src/main/java/com/marverenic/music/player/QueuedMediaPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/QueuedMediaPlayer.java
@@ -18,8 +18,6 @@ public interface QueuedMediaPlayer {
 
     int getQueueSize();
 
-    void setQueue(@NonNull List<Song> queue);
-
     void setQueue(@NonNull List<Song> queue, int index);
 
     void setQueueIndex(int index);

--- a/app/src/main/java/com/marverenic/music/viewmodel/QueueSongViewModel.java
+++ b/app/src/main/java/com/marverenic/music/viewmodel/QueueSongViewModel.java
@@ -125,7 +125,7 @@ public class QueueSongViewModel extends SongViewModel {
         PlayerController.editQueue(getSongs(), newQueuePosition);
 
         if (oldQueuePosition == itemPosition) {
-            PlayerController.begin();
+            PlayerController.play();
         }
 
         mRemoveListener.onRemove();
@@ -138,7 +138,7 @@ public class QueueSongViewModel extends SongViewModel {
                     getSongs().add(itemPosition, removed);
                     PlayerController.editQueue(getSongs(), oldQueuePosition);
                     if (oldQueuePosition == itemPosition) {
-                        PlayerController.begin();
+                        PlayerController.play();
                     }
                     mRemoveListener.onRemove();
                 })

--- a/app/src/main/java/com/marverenic/music/viewmodel/SongViewModel.java
+++ b/app/src/main/java/com/marverenic/music/viewmodel/SongViewModel.java
@@ -82,7 +82,7 @@ public class SongViewModel extends BaseObservable {
     public View.OnClickListener onClickSong() {
         return v -> {
             PlayerController.setQueue(mSongList, mIndex);
-            PlayerController.begin();
+            PlayerController.play();
 
             if (mPrefStore.openNowPlayingOnNewQueue()) {
                 mContext.startActivity(NowPlayingActivity.newIntent(mContext));


### PR DESCRIPTION
Resolves an issue where changing the queue would not correctly update playback.

**Reproduction steps:**
 - Play music a song from the "Songs" tab of the library
 - Play the same song from somewhere else (e.g. the album page or a playlist)

**Expected behavior:**
 - The chosen song should play, and the queue should update with the songs from the page that was selected

**Actual behavior:**
 - The queue would be changed, but a different song may start playing