### PR TITLE
Fix potential startup crash

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -38,7 +38,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     /**
      * The service instance in use (singleton)
      */
-    @Internal static PlayerService instance;
+    private static PlayerService instance;
 
     /**
      * Used in binding and unbinding this service to the UI process
@@ -69,7 +69,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         Timber.i("onBind called");
 
         if (binder == null) {
-            binder = new Stub();
+            binder = new Stub(this);
         }
         mAppRunning = true;
         return binder;
@@ -306,19 +306,20 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
     public static class Stub extends IPlayerService.Stub {
 
+        private PlayerService mService;
+
+        public Stub(PlayerService service) {
+            mService = service;
+        }
+
         private boolean isMusicPlayerReady() {
-            return instance != null && instance.musicPlayer != null;
+            return mService != null && mService.musicPlayer != null;
         }
 
         @Override
         public void stop() throws RemoteException {
-            if (instance == null) {
-                Timber.i("PlayerService.stop(): Service is not ready. Dropping command");
-                return;
-            }
-
             try {
-                instance.stop();
+                mService.stop();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.stop() failed");
                 throw exception;
@@ -333,7 +334,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.skip();
+                mService.musicPlayer.skip();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.skip() failed");
                 throw exception;
@@ -348,7 +349,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.skipPrevious();
+                mService.musicPlayer.skipPrevious();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.previous() failed");
                 throw exception;
@@ -363,7 +364,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.togglePlay();
+                mService.musicPlayer.togglePlay();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.togglePlay() failed");
                 throw exception;
@@ -378,7 +379,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.play();
+                mService.musicPlayer.play();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.play() failed");
                 throw exception;
@@ -393,7 +394,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.pause();
+                mService.musicPlayer.pause();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.pause() failed");
                 throw exception;
@@ -408,7 +409,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.updatePreferences(preferences);
+                mService.musicPlayer.updatePreferences(preferences);
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.setPreferences(...) failed");
                 throw exception;
@@ -423,9 +424,9 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.setQueue(newQueue, newPosition);
+                mService.musicPlayer.setQueue(newQueue, newPosition);
                 if (newQueue.isEmpty()) {
-                    instance.stop();
+                    mService.stop();
                 }
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.setQueue(...) failed");
@@ -441,7 +442,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.changeSong(position);
+                mService.musicPlayer.changeSong(position);
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.changeSong(...) failed");
                 throw exception;
@@ -456,7 +457,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.editQueue(newQueue, newPosition);
+                mService.musicPlayer.editQueue(newQueue, newPosition);
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.editQueue(...) failed");
                 throw exception;
@@ -471,7 +472,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.queueNext(song);
+                mService.musicPlayer.queueNext(song);
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.queueNext(...) failed");
                 throw exception;
@@ -486,7 +487,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.queueNext(songs);
+                mService.musicPlayer.queueNext(songs);
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.queueNextList(...) failed");
                 throw exception;
@@ -501,7 +502,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.queueLast(song);
+                mService.musicPlayer.queueLast(song);
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.queueLast() failed");
                 throw exception;
@@ -516,7 +517,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.queueLast(songs);
+                mService.musicPlayer.queueLast(songs);
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.queueLastList(...) failed");
                 throw exception;
@@ -531,7 +532,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.seekTo(position);
+                mService.musicPlayer.seekTo(position);
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.seekTo() failed");
                 throw exception;
@@ -545,7 +546,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                return instance.musicPlayer.isPlaying();
+                return mService.musicPlayer.isPlaying();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.isPlaying() failed");
                 throw exception;
@@ -559,7 +560,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                return instance.musicPlayer.getNowPlaying();
+                return mService.musicPlayer.getNowPlaying();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.getNowPlaying() failed");
                 throw exception;
@@ -573,7 +574,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                return instance.musicPlayer.getQueue();
+                return mService.musicPlayer.getQueue();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.editQueue() failed");
                 throw exception;
@@ -587,7 +588,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                return instance.musicPlayer.getQueuePosition();
+                return mService.musicPlayer.getQueuePosition();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.getQueuePosition() failed");
                 throw exception;
@@ -601,7 +602,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                return instance.musicPlayer.getQueueSize();
+                return mService.musicPlayer.getQueueSize();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.getQueueSize() failed");
                 throw exception;
@@ -615,7 +616,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                return instance.musicPlayer.getCurrentPosition();
+                return mService.musicPlayer.getCurrentPosition();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.getCurrentPosition() failed");
                 throw exception;
@@ -629,7 +630,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                return instance.musicPlayer.getDuration();
+                return mService.musicPlayer.getDuration();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.getDuration() failed");
                 throw exception;
@@ -643,7 +644,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                return instance.musicPlayer.getMultiRepeatCount();
+                return mService.musicPlayer.getMultiRepeatCount();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.getMultiRepeatCount() failed");
                 throw exception;
@@ -658,7 +659,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.setMultiRepeat(count);
+                mService.musicPlayer.setMultiRepeat(count);
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.setMultiRepeatCount() failed");
                 throw exception;
@@ -672,7 +673,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                return instance.musicPlayer.getSleepTimerEndTime();
+                return mService.musicPlayer.getSleepTimerEndTime();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.getSleepTimerEndTime() failed");
                 throw exception;
@@ -687,7 +688,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             }
 
             try {
-                instance.musicPlayer.setSleepTimer(timestampInMillis);
+                mService.musicPlayer.setSleepTimer(timestampInMillis);
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.setSleepTimerEndTime() failed");
             }

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -24,6 +24,7 @@ import com.marverenic.music.utils.Internal;
 import com.marverenic.music.utils.MediaStyleHelper;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import timber.log.Timber;
@@ -305,8 +306,17 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
     public static class Stub extends IPlayerService.Stub {
 
+        private boolean isMusicPlayerReady() {
+            return instance != null && instance.musicPlayer != null;
+        }
+
         @Override
         public void stop() throws RemoteException {
+            if (instance == null) {
+                Timber.i("PlayerService.stop(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.stop();
             } catch (RuntimeException exception) {
@@ -317,6 +327,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void skip() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.skip(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.skip();
             } catch (RuntimeException exception) {
@@ -327,6 +342,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void previous() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.skip(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.skipPrevious();
             } catch (RuntimeException exception) {
@@ -337,6 +357,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void togglePlay() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.togglePlay(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.togglePlay();
             } catch (RuntimeException exception) {
@@ -347,6 +372,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void play() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.play(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.play();
             } catch (RuntimeException exception) {
@@ -357,6 +387,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void pause() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.pause(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.pause();
             } catch (RuntimeException exception) {
@@ -367,6 +402,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void setPreferences(ImmutablePreferenceStore preferences) throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.setPreferences(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.updatePreferences(preferences);
             } catch (RuntimeException exception) {
@@ -377,6 +417,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void setQueue(List<Song> newQueue, int newPosition) throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.setQueue(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.setQueue(newQueue, newPosition);
                 if (newQueue.isEmpty()) {
@@ -390,6 +435,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void changeSong(int position) throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.changeSong(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.changeSong(position);
             } catch (RuntimeException exception) {
@@ -400,6 +450,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void editQueue(List<Song> newQueue, int newPosition) throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.editQueue(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.editQueue(newQueue, newPosition);
             } catch (RuntimeException exception) {
@@ -410,6 +465,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void queueNext(Song song) throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.queueNext(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.queueNext(song);
             } catch (RuntimeException exception) {
@@ -420,6 +480,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void queueNextList(List<Song> songs) throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.queueNextList(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.queueNext(songs);
             } catch (RuntimeException exception) {
@@ -430,6 +495,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void queueLast(Song song) throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.queueLast(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.queueLast(song);
             } catch (RuntimeException exception) {
@@ -440,6 +510,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void queueLastList(List<Song> songs) throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.queueLastList(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.queueLast(songs);
             } catch (RuntimeException exception) {
@@ -450,6 +525,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void seekTo(int position) throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.seekTo(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.seekTo(position);
             } catch (RuntimeException exception) {
@@ -460,6 +540,10 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public boolean isPlaying() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                return false;
+            }
+
             try {
                 return instance.musicPlayer.isPlaying();
             } catch (RuntimeException exception) {
@@ -470,6 +554,10 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public Song getNowPlaying() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                return null;
+            }
+
             try {
                 return instance.musicPlayer.getNowPlaying();
             } catch (RuntimeException exception) {
@@ -480,6 +568,10 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public List<Song> getQueue() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                return Collections.emptyList();
+            }
+
             try {
                 return instance.musicPlayer.getQueue();
             } catch (RuntimeException exception) {
@@ -490,6 +582,10 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public int getQueuePosition() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                return 0;
+            }
+
             try {
                 return instance.musicPlayer.getQueuePosition();
             } catch (RuntimeException exception) {
@@ -500,6 +596,10 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public int getQueueSize() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                return 0;
+            }
+
             try {
                 return instance.musicPlayer.getQueueSize();
             } catch (RuntimeException exception) {
@@ -510,6 +610,10 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public int getCurrentPosition() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                return 0;
+            }
+
             try {
                 return instance.musicPlayer.getCurrentPosition();
             } catch (RuntimeException exception) {
@@ -520,6 +624,10 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public int getDuration() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                return 0;
+            }
+
             try {
                 return instance.musicPlayer.getDuration();
             } catch (RuntimeException exception) {
@@ -530,6 +638,10 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public int getMultiRepeatCount() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                return 0;
+            }
+
             try {
                 return instance.musicPlayer.getMultiRepeatCount();
             } catch (RuntimeException exception) {
@@ -540,6 +652,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void setMultiRepeatCount(int count) throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.setMultiRepeat(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.setMultiRepeat(count);
             } catch (RuntimeException exception) {
@@ -550,6 +667,10 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public long getSleepTimerEndTime() throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                return 0;
+            }
+
             try {
                 return instance.musicPlayer.getSleepTimerEndTime();
             } catch (RuntimeException exception) {
@@ -560,6 +681,11 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public void setSleepTimerEndTime(long timestampInMillis) throws RemoteException {
+            if (!isMusicPlayerReady()) {
+                Timber.i("PlayerService.setSleepTimer(): Service is not ready. Dropping command");
+                return;
+            }
+
             try {
                 instance.musicPlayer.setSleepTimer(timestampInMillis);
             } catch (RuntimeException exception) {

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -20,6 +20,7 @@ import com.marverenic.music.R;
 import com.marverenic.music.data.store.ImmutablePreferenceStore;
 import com.marverenic.music.data.store.MediaStoreUtil;
 import com.marverenic.music.model.Song;
+import com.marverenic.music.utils.Internal;
 import com.marverenic.music.utils.MediaStyleHelper;
 
 import java.io.IOException;
@@ -36,7 +37,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     /**
      * The service instance in use (singleton)
      */
-    private static PlayerService instance;
+    @Internal static PlayerService instance;
 
     /**
      * Used in binding and unbinding this service to the UI process
@@ -47,7 +48,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     /**
      * The media player for the service instance
      */
-    private MusicPlayer musicPlayer;
+    @Internal MusicPlayer musicPlayer;
 
     /**
      * Used to to prevent errors caused by freeing resources twice

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -358,7 +358,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         @Override
         public void pause() throws RemoteException {
             try {
-                instance.musicPlayer.play();
+                instance.musicPlayer.pause();
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.pause() failed");
                 throw exception;


### PR DESCRIPTION
Fixes a potential crash where the service binder may be returned to the main thread before the service has finished its call to `onCreate()`. Previously, this would cause accesses and commands to the service to throw NPEs to the main thread. This implementation simply drops all incoming commands if the service has not finished its `onCreate()` call before data is accessed.