### PR TITLE
Fix AudioFocus not being regained correctly

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -460,11 +460,12 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
 
         switch (focusChange) {
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-                mResumeOnFocusGain = isPlaying() || mResumeOnFocusGain;
             case AudioManager.AUDIOFOCUS_LOSS:
                 Timber.i("Focus lost. Pausing music.");
+                boolean resume = isPlaying() || mResumeOnFocusGain;
                 mFocused = false;
                 pause();
+                mResumeOnFocusGain = resume;
                 break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
                 Timber.i("Focus lost transiently. Ducking.");

--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -459,9 +459,14 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
         Timber.i("AudioFocus changed (%d)", focusChange);
 
         switch (focusChange) {
-            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
             case AudioManager.AUDIOFOCUS_LOSS:
                 Timber.i("Focus lost. Pausing music.");
+                mFocused = false;
+                mResumeOnFocusGain = false;
+                pause();
+                break;
+            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+                Timber.i("Focus lost transiently. Pausing music.");
                 boolean resume = isPlaying() || mResumeOnFocusGain;
                 mFocused = false;
                 pause();


### PR DESCRIPTION
Resolves an issue where audio focus would never be regained after it was lost (either fully or transiently). This allows music to resume automatically after a phone call ends. Closes #43.