### PR TITLE
Fix service restart behavior

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -160,7 +160,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             Timber.e(exception, "Failed to save music player state");
         }
 
-        if (mStopped) {
+        if (mStopped || !musicPlayer.isPlaying()) {
             NotificationManager mgr = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
             mgr.cancel(NOTIFICATION_ID);
 

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -1,5 +1,6 @@
 package com.marverenic.music.player;
 
+import android.app.ActivityManager;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -15,6 +16,7 @@ import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v7.app.NotificationCompat;
 import android.view.KeyEvent;
 
+import com.marverenic.music.BuildConfig;
 import com.marverenic.music.IPlayerService;
 import com.marverenic.music.R;
 import com.marverenic.music.data.store.ImmutablePreferenceStore;
@@ -56,10 +58,6 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
      */
     private boolean finished;
     /**
-     * Used to keep track of whether the main application window is open or not
-     */
-    private boolean mAppRunning;
-    /**
      * Used to keep track of whether the notification has been dismissed or not
      */
     private boolean mStopped;
@@ -71,7 +69,6 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         if (binder == null) {
             binder = new Stub(this);
         }
-        mAppRunning = true;
         return binder;
     }
 
@@ -134,7 +131,6 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     @Override
     public void onTaskRemoved(Intent rootIntent) {
         Timber.i("onTaskRemoved called");
-        mAppRunning = false;
 
         /*
             When the application is removed from the overview page, we make the notification
@@ -276,13 +272,30 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
     }
 
+    private boolean isUiProcessRunning() {
+        ActivityManager am = (ActivityManager) getSystemService(ACTIVITY_SERVICE);
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            List<ActivityManager.RunningAppProcessInfo> processes = am.getRunningAppProcesses();
+            for (int i = 0; i < processes.size(); i++) {
+                if (processes.get(i).processName.equals(BuildConfig.APPLICATION_ID)) {
+                    return true;
+                }
+            }
+
+            return false;
+        } else {
+            return !am.getAppTasks().isEmpty();
+        }
+    }
+
     public void stop() {
         Timber.i("stop called");
 
         mStopped = true;
 
         // If the UI process is still running, don't kill the process, only remove its notification
-        if (mAppRunning) {
+        if (isUiProcessRunning()) {
             musicPlayer.pause();
             stopForeground(true);
             return;

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -254,7 +254,20 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             startForeground(NOTIFICATION_ID, notification);
         } else if (!musicPlayer.isPlaying()) {
+            Timber.i("Removing service from foreground");
+
+            /*
+               The following call to startService is a workaround for API 21 and 22 devices. If the
+               main UI process is not running, then calling stopForeground() here will end the
+               service completely. We therefore have the service start itself. If the service does
+               then get killed, it will be restarted automatically. If the service doesn't get
+               killed (regardless of API level), then this call does nothing since Android won't
+               start a second instance of a service.
+            */
+            startService(new Intent(this, PlayerService.class));
+
             stopForeground(false);
+            Timber.i("Bringing service into background");
 
             NotificationManager mgr = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
             mgr.notify(NOTIFICATION_ID, notification);

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -161,7 +161,10 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         if (mStopped) {
-            stop();
+            NotificationManager mgr = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+            mgr.cancel(NOTIFICATION_ID);
+
+            finish();
         } else {
             notifyNowPlaying();
         }

--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -105,12 +105,14 @@ public class ServicePlayerController implements PlayerController {
 
             @Override
             public void onServiceDisconnected(ComponentName name) {
-                // TODO restart service after crash
+                mContext.unbindService(this);
+                releaseAllProperties();
                 mBinding = null;
                 if (mRequestQueueSubscription != null) {
                     mRequestQueueSubscription.unsubscribe();
                     mRequestQueueSubscription = null;
                 }
+                startService();
             }
         }, Context.BIND_WAIVE_PRIORITY);
     }
@@ -152,6 +154,17 @@ public class ServicePlayerController implements PlayerController {
             mCurrentPositionClock.unsubscribe();
             mCurrentPositionClock = null;
         }
+    }
+
+    private void releaseAllProperties() {
+        mPlaying.setFunction(null);
+        mNowPlaying.setFunction(null);
+        mQueue.setFunction(null);
+        mQueuePosition.setFunction(null);
+        mCurrentPosition.setFunction(null);
+        mDuration.setFunction(null);
+        mMultiRepeatCount.setFunction(null);
+        mSleepTimerEndTime.setFunction(null);
     }
 
     private void initAllProperties() {

--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -112,9 +112,14 @@ public class ServicePlayerController implements PlayerController {
                     mRequestQueueSubscription.unsubscribe();
                     mRequestQueueSubscription = null;
                 }
-                startService();
             }
         }, Context.BIND_WAIVE_PRIORITY);
+    }
+
+    private void ensureServiceStarted() {
+        if (mBinding == null) {
+            startService();
+        }
     }
 
     private void bindRequestQueue() {
@@ -128,6 +133,7 @@ public class ServicePlayerController implements PlayerController {
     }
 
     private void execute(Runnable command) {
+        ensureServiceStarted();
         mRequestQueue.enqueue(command);
     }
 
@@ -407,42 +413,50 @@ public class ServicePlayerController implements PlayerController {
 
     @Override
     public Observable<Boolean> isPlaying() {
+        ensureServiceStarted();
         return mPlaying.getObservable();
     }
 
     @Override
     public Observable<Song> getNowPlaying() {
+        ensureServiceStarted();
         return mNowPlaying.getObservable();
     }
 
     @Override
     public Observable<List<Song>> getQueue() {
+        ensureServiceStarted();
         return mQueue.getObservable();
     }
 
     @Override
     public Observable<Integer> getQueuePosition() {
+        ensureServiceStarted();
         return mQueuePosition.getObservable();
     }
 
     @Override
     public Observable<Integer> getCurrentPosition() {
+        ensureServiceStarted();
         startCurrentPositionClock();
         return mCurrentPosition.getObservable();
     }
 
     @Override
     public Observable<Integer> getDuration() {
+        ensureServiceStarted();
         return mDuration.getObservable();
     }
 
     @Override
     public Observable<Boolean> isShuffleEnabled() {
+        ensureServiceStarted();
         return mShuffled.asObservable().distinctUntilChanged();
     }
 
     @Override
     public Observable<Integer> getMultiRepeatCount() {
+        ensureServiceStarted();
         return mMultiRepeatCount.getObservable();
     }
 
@@ -460,6 +474,7 @@ public class ServicePlayerController implements PlayerController {
 
     @Override
     public Observable<Long> getSleepTimerEndTime() {
+        ensureServiceStarted();
         return mSleepTimerEndTime.getObservable();
     }
 

--- a/app/src/main/java/com/marverenic/music/widget/BaseWidget.java
+++ b/app/src/main/java/com/marverenic/music/widget/BaseWidget.java
@@ -23,7 +23,9 @@ public abstract class BaseWidget extends AppWidgetProvider {
 
         String action = intent.getAction();
         if (MusicPlayer.UPDATE_BROADCAST.equals(action)) {
-            onUpdate(context);
+            if (isEnabled(context)) {
+                onUpdate(context);
+            }
         } else {
             super.onReceive(context, intent);
         }


### PR DESCRIPTION
Fixes a number of issues related to restarting the service. The main issue fixed is the service notification reappearing after stopping the service and removing Jockey from the list of recent apps. One minor behavior change associated with this is that if music is paused and Jockey is removed from the list of recent apps, then the service will be stopped and its notification will always be removed.

This also fixes a bug introduced in #192 on KitKat where the service would be killed and not restarted after pausing music when the app was not in the list of recent apps.