### PR TITLE
Fix duration initializing to 0 on cold start

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/QueuedExoPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/QueuedExoPlayer.java
@@ -366,6 +366,8 @@ public class QueuedExoPlayer implements QueuedMediaPlayer {
     public int getDuration() {
         if (mExoPlayer.getDuration() > 0) {
             mPrevDuration = (int) mExoPlayer.getDuration();
+        } else if (mPrevDuration <= 0 && getNowPlaying() != null) {
+            return (int) getNowPlaying().getSongDuration();
         }
 
         return mPrevDuration;


### PR DESCRIPTION
Fixes an issue where seek position appears invalid after a cold start. This is because ExoPlayer does not resolve a duration until a song has finished loading. The current workaround is to check if ExoPlayer returns an invalid duration. If it does return an invalid duration, it returns the last valid duration. If there isn't one, it defaults to the duration embedded in the song object. This may be inaccurate since it's pulled from the MediaStore, but should work most of the time.