### PR TITLE
Fix service not binding to app after restart

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -8,6 +8,7 @@ import android.app.Service;
 import android.content.Intent;
 import android.os.Build;
 import android.os.IBinder;
+import android.os.Process;
 import android.os.RemoteException;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.StringRes;
@@ -125,7 +126,17 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     public void onDestroy() {
         Timber.i("Called onDestroy");
         finish();
-        super.onDestroy();
+
+        /*
+            By default, when this service stops, Android will keep a cached version of it so it can
+            be restarted easily. When this happens, the service enters a state where the main app
+            can no longer bind to it when it is started the next time. We therefore prevent this
+            entirely by not allowing Android to keep the service process cached.
+
+            This is a VERY bad idea, so make sure that this service always has its own process, and
+            make sure to be very careful about cleaning up all resources before this method returns.
+         */
+        Process.killProcess(Process.myPid());
     }
 
     @Override


### PR DESCRIPTION
Fixes a bug where closing and restarting Jockey would not allow the UI to control music playback. To reproduce, start Jockey, play music, remove the app from the recent tasks, and stop the service by dismissing it. Then, restart Jockey. The service will reappear and can play music, but the UI cannot be used to control playback.