### PR TITLE
Fix appending to the queue not invalidating the ExoPlayer Timeline

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -585,7 +585,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      */
     private void shuffleQueue(int currentIndex) {
         Timber.i("Shuffling queue...");
-        mQueueShuffled = new ArrayList<>(mQueue);
+        ArrayList<Song> shuffled = new ArrayList<>(mQueue);
 
         if (!mQueueShuffled.isEmpty()) {
             Song first = mQueueShuffled.remove(currentIndex);
@@ -593,6 +593,8 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
             Collections.shuffle(mQueueShuffled);
             mQueueShuffled.add(0, first);
         }
+
+        mQueueShuffled = Collections.unmodifiableList(shuffled);
     }
 
     /**
@@ -613,7 +615,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
             }
         }
 
-        mQueue = unshuffled;
+        mQueue = Collections.unmodifiableList(unshuffled);
     }
 
     /**
@@ -852,7 +854,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
         // If you're using this method on the UI thread, consider replacing the first line in this
         // method with "mQueue = new ArrayList<>(queue);"
         // to prevent components from accidentally changing the backing queue
-        mQueue = queue;
+        mQueue = Collections.unmodifiableList(queue);
         if (mShuffle) {
             Timber.i("Shuffling new queue and starting from beginning");
             shuffleQueue(index);
@@ -874,9 +876,9 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
     public void editQueue(@NonNull List<Song> queue, int index) {
         Timber.i("editQueue called (index = %d)", index);
         if (mShuffle) {
-            mQueueShuffled = queue;
+            mQueueShuffled = Collections.unmodifiableList(queue);
         } else {
-            mQueue = queue;
+            mQueue = Collections.unmodifiableList(queue);
         }
         setBackingQueue(index);
     }
@@ -1035,12 +1037,20 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
     public void queueNext(Song song) {
         Timber.i("queueNext(Song) called");
         int index = mQueue.isEmpty() ? 0 : mMediaPlayer.getQueueIndex() + 1;
+
+        List<Song> shuffledQueue = new ArrayList<>(mQueueShuffled);
+        List<Song> queue = new ArrayList<>(mQueue);
+
         if (mShuffle) {
-            mQueueShuffled.add(index, song);
-            mQueue.add(song);
+            shuffledQueue.add(index, song);
+            queue.add(song);
         } else {
-            mQueue.add(index, song);
+            queue.add(index, song);
         }
+
+        mQueueShuffled = Collections.unmodifiableList(shuffledQueue);
+        mQueue = Collections.unmodifiableList(queue);
+
         setBackingQueue();
     }
 
@@ -1051,12 +1061,20 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
     public void queueNext(List<Song> songs) {
         Timber.i("queueNext(List<Song>) called");
         int index = mQueue.isEmpty() ? 0 : mMediaPlayer.getQueueIndex() + 1;
+
+        List<Song> shuffledQueue = new ArrayList<>(mQueueShuffled);
+        List<Song> queue = new ArrayList<>(mQueue);
+
         if (mShuffle) {
-            mQueueShuffled.addAll(index, songs);
-            mQueue.addAll(songs);
+            shuffledQueue.addAll(index, songs);
+            queue.addAll(songs);
         } else {
-            mQueue.addAll(index, songs);
+            queue.addAll(index, songs);
         }
+
+        mQueueShuffled = Collections.unmodifiableList(shuffledQueue);
+        mQueue = Collections.unmodifiableList(queue);
+
         setBackingQueue();
     }
 
@@ -1066,12 +1084,20 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      */
     public void queueLast(Song song) {
         Timber.i("queueLast(Song) called");
+
+        List<Song> shuffledQueue = new ArrayList<>(mQueueShuffled);
+        List<Song> queue = new ArrayList<>(mQueue);
+
         if (mShuffle) {
-            mQueueShuffled.add(song);
-            mQueue.add(song);
+            shuffledQueue.add(song);
+            queue.add(song);
         } else {
-            mQueue.add(song);
+            queue.add(song);
         }
+
+        mQueueShuffled = Collections.unmodifiableList(shuffledQueue);
+        mQueue = Collections.unmodifiableList(queue);
+
         setBackingQueue();
     }
 
@@ -1081,12 +1107,20 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      */
     public void queueLast(List<Song> songs) {
         Timber.i("queueLast(List<Song>)");
+
+        List<Song> shuffledQueue = new ArrayList<>(mQueueShuffled);
+        List<Song> queue = new ArrayList<>(mQueue);
+
         if (mShuffle) {
-            mQueueShuffled.addAll(songs);
-            mQueue.addAll(songs);
+            shuffledQueue.addAll(songs);
+            queue.addAll(songs);
         } else {
-            mQueue.addAll(songs);
+            queue.addAll(songs);
         }
+
+        mQueueShuffled = Collections.unmodifiableList(shuffledQueue);
+        mQueue = Collections.unmodifiableList(queue);
+
         setBackingQueue();
     }
 
@@ -1176,8 +1210,8 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      *              status will immediately be applied.
      */
     public void restorePlayerState(PlayerState state) {
-        mQueue = state.getQueue();
-        mQueueShuffled = state.getShuffledQueue();
+        mQueue = Collections.unmodifiableList(state.getQueue());
+        mQueueShuffled = Collections.unmodifiableList(state.getShuffledQueue());
 
         setBackingQueue(state.getQueuePosition());
         seekTo(state.getSeekPosition());

--- a/app/src/main/java/com/marverenic/music/player/QueuedExoPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/QueuedExoPlayer.java
@@ -31,6 +31,7 @@ import com.marverenic.music.BuildConfig;
 import com.marverenic.music.model.Song;
 import com.marverenic.music.utils.Internal;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -217,7 +218,7 @@ public class QueuedExoPlayer implements QueuedMediaPlayer {
             boolean nowPlayingDiff = !queue.get(index).equals(getNowPlaying());
             boolean queueDiff = !queue.equals(mQueue);
 
-            mQueue = queue;
+            mQueue = Collections.unmodifiableList(new ArrayList<>(queue));
             mQueueIndex = index;
 
             if (nowPlayingDiff) {


### PR DESCRIPTION
Resolves an issue where queue list modifications would not be reflected in music playback because of an issue where the queue reference was shared between the MusicPlayer and QueuedExoPlayer classes. This is avoided by making immutable copies of the queue.

**Reproduction steps:**
 - Start playback of a new queue
 - Add another song the queue (this can be any song, but it's more noticeable if it's not the next song in the queue)
 - Skip to the song that was added (either with the skip button or by selecting it on the queue page)

**Expected behavior:**
 - The song that was enqueued should start playing

**Actual behavior:**
 - The UI shows that the enqueued song is playing, but music playback acts like the song was never enqueued