### PR TITLE
Fix queue not changing with shuffle enabled after restarting Jockey

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -587,11 +587,11 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
         Timber.i("Shuffling queue...");
         ArrayList<Song> shuffled = new ArrayList<>(mQueue);
 
-        if (!mQueueShuffled.isEmpty()) {
-            Song first = mQueueShuffled.remove(currentIndex);
+        if (!shuffled.isEmpty()) {
+            Song first = shuffled.remove(currentIndex);
 
-            Collections.shuffle(mQueueShuffled);
-            mQueueShuffled.add(0, first);
+            Collections.shuffle(shuffled);
+            shuffled.add(0, first);
         }
 
         mQueueShuffled = Collections.unmodifiableList(shuffled);


### PR DESCRIPTION
**Reproduction steps:**
 - Play music with shuffle enabled
 - Close and restart Jockey
 - Navigate to any part of the library, and select a new song to start playing

 **Expected behavior:**
 - The selected song should start playing and the queue should be changed

**Actual behavior:**
 - The queue will not be changed, and playback will be unaffected