### PR TITLE
Fix notification reappearing after AudioFocus changes

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -273,7 +273,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     }
 
     private void showNotification(Notification notification) {
-        if (mBeQuiet && !musicPlayer.isPlaying()) {
+        if ((mBeQuiet || mStopped) && !musicPlayer.isPlaying()) {
             return;
         }
 


### PR DESCRIPTION
Fixes an issue where changes to the app's AudioFocus could cause the service notification to reappear. Closes #224.

**Reproduction Steps:**
- Start Jockey and play music
- Pause music and dismiss the notification, but leave Jockey running in the background
- Perform an action that removes audio focus from Jockey (e.g. accepting a phone call)

**Expected Behavior:**
- The notification should remain hidden until music is played again

**Actual Behavior:**
- The notification will reappear