### PR TITLE
Reduce Travis CI Build Time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ android:
         - extra-android-support
         - extra-google-m2repository
         - extra-android-m2repository
-script: ./gradlew clean assemble test -PdisablePreDex
+script: ./gradlew clean assembleStandardRelease testStandardRelease -PdisablePreDex
 notifications:
     email: false


### PR DESCRIPTION
This should improve the speed of Travis Builds by only compiling and testing release builds of Jockey