### PR TITLE
Catch errors from MediaMetadataRetriever

### DIFF
--- a/app/src/main/java/com/marverenic/music/utils/Util.java
+++ b/app/src/main/java/com/marverenic/music/utils/Util.java
@@ -131,7 +131,7 @@ public final class Util {
             if (stream != null) {
                 return BitmapFactory.decodeByteArray(stream, 0, stream.length);
             }
-        } catch (IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             Timber.e(e, "Failed to load full song artwork");
         } catch (OutOfMemoryError e) {
             Timber.e(e, "Unable to allocate space on the heap for full song artwork");


### PR DESCRIPTION
MediaMetadataRetriever throws a RuntimeException (not a descendant) when an error occurrs. This commit catches these errors and returns null when an error is thrown to prevent the player service from crashing.