### PR TITLE
Fix crash when starting Jockey with repeat 1 and an empty queue

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/QueuedExoPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/QueuedExoPlayer.java
@@ -277,6 +277,12 @@ public class QueuedExoPlayer implements QueuedMediaPlayer {
     private MediaSource buildRepeatOneMediaSource(DataSource.Factory srcFactory,
                                                   ExtractorsFactory extFactory) {
 
+        if (mQueue.isEmpty()) {
+            // We need to return an empty MediaSource (can't be null), so return a
+            // ConcatenatingMediaSource with nothing to concatenate
+            return new ConcatenatingMediaSource();
+        }
+
         Uri uri = mQueue.get(mQueueIndex).getLocation();
         MediaSource source = new ExtractorMediaSource(uri, srcFactory, extFactory, null, null);
         return new LoopingMediaSource(source);


### PR DESCRIPTION
Fixes an IndexOutOfBoundsException thrown when building a repeat-one timeline when the queue is empty.