### PR TITLE
Correct include/exclude folder query

### DIFF
--- a/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
+++ b/app/src/main/java/com/marverenic/music/data/store/LocalMusicStore.java
@@ -225,10 +225,10 @@ public class LocalMusicStore implements MusicStore {
         } else if (excludeSelection != null) {
             selection = excludeSelection;
         } else {
-            selection = null;
+            return null;
         }
 
-        return selection;
+        return "(" + selection + ")";
     }
 
     private String getDirectoryInclusionSelection() {


### PR DESCRIPTION
When I include folder `/sdcard/foo` and `/sdcard/bar`, Jockey's query command for album be like:
```sql
album_id = 123 AND _data LIKE '/sdcard/foo/%' OR _data LIKE '/sdcard/bar/%'
```
But It should be:
```sql
album_id = 123 AND (_data LIKE '/sdcard/foo/%' OR _data LIKE '/sdcard/bar/%')
```
