### PR TITLE
Prevent proguard from stripping code with Keep annotations

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -5,6 +5,13 @@
 -dontpreverify
 -optimizations !code/simplification/arithmetic,!field/*,!class/merging/*
 
+# Keep everything annotated with @Keep
+-keep,allowobfuscation @interface android.support.annotation.Keep
+-keep @android.support.annotation.Keep class *
+-keepclassmembers class * {
+    @android.support.annotation.Keep *;
+}
+
 # Glide rules
 -keep public class * implements com.bumptech.glide.module.GlideModule
 -keep public enum com.bumptech.glide.load.resource.bitmap.ImageHeaderParser$** {


### PR DESCRIPTION
Resolves a defect in release builds where gestures would not animate. It seems like the `@Keep` annotation isn't working correctly right now.