### PR TITLE
Reimplement full size album artwork loading

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -580,12 +580,12 @@ public class ServicePlayerController implements PlayerController {
 
             getNowPlaying()
                     .observeOn(Schedulers.io())
-                    .map((Song song) -> {
+                    .flatMap((Song song) -> {
                         if (song == null) {
                             return null;
                         }
 
-                        return Util.fetchFullArt(mContext, song);
+                        return Util.fetchArtwork(mContext, song.getLocation());
                     })
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(mArtwork::onNext, throwable -> {

--- a/app/src/main/java/com/marverenic/music/utils/Util.java
+++ b/app/src/main/java/com/marverenic/music/utils/Util.java
@@ -7,6 +7,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.media.MediaMetadataRetriever;
 import android.media.audiofx.AudioEffect;
 import android.net.ConnectivityManager;
@@ -28,7 +29,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
 import rx.Observable;
-import rx.exceptions.Exceptions;
 import timber.log.Timber;
 
 import static android.content.Context.CONNECTIVITY_SERVICE;
@@ -245,7 +245,9 @@ public final class Util {
                         .into(size, size)
                         .get();
             } catch (InterruptedException|ExecutionException e) {
-                throw Exceptions.propagate(e);
+                Timber.e(e, "Failed to load artwork");
+                return BitmapFactory.decodeResource(context.getResources(),
+                        R.drawable.art_default_xl);
             }
         });
     }


### PR DESCRIPTION
This replaces the old implementation for loading full-size album artwork in favor of one that uses RxJava with Glide. In addition to being easier to move off the main thread, this should also be a bit safer in how it loads images and also allows for more complicated rules to find artwork. For example, in addition to using `MediaMetadataRetriever`, this implementation will then try to fallback to a `cover.jpg` or `folder.jpg` image if available, and then on a thumbnail in the MediaStore before falling back to the default placeholder image.