### PR TITLE
Improve UI responsiveness when performing IPC

### DIFF
--- a/app/src/main/aidl/com/marverenic/music/IPlayerService.aidl
+++ b/app/src/main/aidl/com/marverenic/music/IPlayerService.aidl
@@ -20,7 +20,8 @@ interface IPlayerService {
     void setQueue(in List<Song> newQueue, int newPosition, long seed);
     void beginLargeQueueTransaction(in TransactionToken token);
     void sendQueueChunk(in ChunkHeader header, in List<Song> chunk);
-    void endLargeQueueTransaction(boolean editQueue, int newPosition, long seed);
+    void endLargeQueueEdit(int newPosition);
+    void endLargeQueueTransaction(int newPosition, long seed);
     void changeSong(int position);
     void editQueue(in List<Song> newQueue, int newPosition);
     void queueNext(in Song song);

--- a/app/src/main/aidl/com/marverenic/music/IPlayerService.aidl
+++ b/app/src/main/aidl/com/marverenic/music/IPlayerService.aidl
@@ -16,11 +16,11 @@ interface IPlayerService {
     void togglePlay();
     void play();
     void pause();
-    void setPreferences(in ImmutablePreferenceStore preferences);
-    void setQueue(in List<Song> newQueue, int newPosition);
+    void setPreferences(in ImmutablePreferenceStore preferences, long seed);
+    void setQueue(in List<Song> newQueue, int newPosition, long seed);
     void beginLargeQueueTransaction(in TransactionToken token);
     void sendQueueChunk(in ChunkHeader header, in List<Song> chunk);
-    void endLargeQueueTransaction(boolean editQueue, int newPosition);
+    void endLargeQueueTransaction(boolean editQueue, int newPosition, long seed);
     void changeSong(int position);
     void editQueue(in List<Song> newQueue, int newPosition);
     void queueNext(in Song song);

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -470,14 +470,14 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void setPreferences(ImmutablePreferenceStore preferences) throws RemoteException {
+        public void setPreferences(ImmutablePreferenceStore preferences, long seed) throws RemoteException {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.setPreferences(): Service is not ready. Dropping command");
                 return;
             }
 
             try {
-                mService.musicPlayer.updatePreferences(preferences);
+                mService.musicPlayer.updatePreferences(preferences, seed);
             } catch (RuntimeException exception) {
                 Timber.e(exception, "Remote call to PlayerService.setPreferences(...) failed");
                 throw exception;
@@ -485,14 +485,14 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void setQueue(List<Song> newQueue, int newPosition) throws RemoteException {
+        public void setQueue(List<Song> newQueue, int newPosition, long seed) throws RemoteException {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.setQueue(): Service is not ready. Dropping command");
                 return;
             }
 
             try {
-                mService.musicPlayer.setQueue(newQueue, newPosition);
+                mService.musicPlayer.setQueue(newQueue, newPosition, seed);
                 if (newQueue.isEmpty()) {
                     mService.stop();
                 }
@@ -516,7 +516,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void endLargeQueueTransaction(boolean editQueue, int newPosition) throws RemoteException {
+        public void endLargeQueueTransaction(boolean editQueue, int newPosition, long seed) throws RemoteException {
             if (mQueueTransaction == null) {
                 throw new IllegalStateException("Transaction has not started");
             } else if (!mQueueTransaction.isTransmissionComplete()) {
@@ -526,7 +526,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
             if (editQueue) {
                 editQueue(mQueueTransaction.getData(), newPosition);
             } else {
-                setQueue(mQueueTransaction.getData(), newPosition);
+                setQueue(mQueueTransaction.getData(), newPosition, seed);
             }
             mQueueTransaction = null;
         }

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -516,18 +516,28 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void endLargeQueueTransaction(boolean editQueue, int newPosition, long seed) throws RemoteException {
-            if (mQueueTransaction == null) {
+        public void endLargeQueueTransaction(int newPosition, long seed) throws RemoteException {
+            IncomingTransaction<List<Song>> transaction = mQueueTransaction;
+            if (transaction == null) {
                 throw new IllegalStateException("Transaction has not started");
-            } else if (!mQueueTransaction.isTransmissionComplete()) {
+            } else if (!transaction.isTransmissionComplete()) {
                 throw new IllegalStateException("Transaction has not completed");
             }
 
-            if (editQueue) {
-                editQueue(mQueueTransaction.getData(), newPosition);
-            } else {
-                setQueue(mQueueTransaction.getData(), newPosition, seed);
+            setQueue(transaction.getData(), newPosition, seed);
+            mQueueTransaction = null;
+        }
+
+        @Override
+        public void endLargeQueueEdit(int newPosition) throws RemoteException {
+            IncomingTransaction<List<Song>> transaction = mQueueTransaction;
+            if (transaction == null) {
+                throw new IllegalStateException("Transaction has not started");
+            } else if (!transaction.isTransmissionComplete()) {
+                throw new IllegalStateException("Transaction has not completed");
             }
+
+            editQueue(mQueueTransaction.getData(), newPosition);
             mQueueTransaction = null;
         }
 

--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -267,6 +267,8 @@ public class ServicePlayerController implements PlayerController {
 
     @Override
     public void stop() {
+        mPlaying.setValue(false);
+
         execute(() -> {
             try {
                 mBinding.stop();
@@ -303,6 +305,10 @@ public class ServicePlayerController implements PlayerController {
 
     @Override
     public void togglePlay() {
+        if (mPlaying.hasValue()) {
+            mPlaying.setValue(!mPlaying.lastValue());
+        }
+
         execute(() -> {
             try {
                 mBinding.togglePlay();
@@ -315,6 +321,8 @@ public class ServicePlayerController implements PlayerController {
 
     @Override
     public void play() {
+        mPlaying.setValue(true);
+
         execute(() -> {
             try {
                 mBinding.play();
@@ -327,6 +335,8 @@ public class ServicePlayerController implements PlayerController {
 
     @Override
     public void pause() {
+        mPlaying.setValue(false);
+
         execute(() -> {
             try {
                 mBinding.pause();
@@ -355,6 +365,12 @@ public class ServicePlayerController implements PlayerController {
 
     @Override
     public void setQueue(List<Song> newQueue, int newPosition) {
+        if (newPosition < newQueue.size()) {
+            mNowPlaying.setValue(newQueue.get(newPosition));
+            mQueuePosition.setValue(mShuffled.getValue() ? 0 : newPosition);
+            mCurrentPosition.setValue(0);
+        }
+
         execute(() -> {
             try {
                 if (newQueue.size() > MAXIMUM_CHUNK_ENTRIES) {
@@ -491,6 +507,8 @@ public class ServicePlayerController implements PlayerController {
 
     @Override
     public void seek(int position) {
+        mCurrentPosition.setValue(position);
+
         execute(() -> {
             try {
                 mBinding.seekTo(position);
@@ -705,6 +723,14 @@ public class ServicePlayerController implements PlayerController {
 
         public void setValue(T value) {
             mSubject.onNext(Optional.ofNullable(value));
+        }
+
+        public boolean hasValue() {
+            return mSubject.getValue() != null && mSubject.getValue().isPresent();
+        }
+
+        public T lastValue() {
+            return mSubject.getValue().getValue();
         }
 
         public Observable<T> getObservable() {

--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -85,7 +85,7 @@ public class ServicePlayerController implements PlayerController {
 
     public ServicePlayerController(Context context, PreferenceStore preferenceStore) {
         mContext = context;
-        mRequestThread = new HandlerThread("PlayerController-RequestProcessor");
+        mRequestThread = new HandlerThread("ServiceExecutor");
         mShuffled = BehaviorSubject.create(preferenceStore.isShuffled());
         mRepeatMode = BehaviorSubject.create(preferenceStore.getRepeatMode());
         mRequestQueue = new ObservableQueue<>();

--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -261,10 +261,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.restorePlayerState(restoreState);
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to restore player state");
             }
+            invalidateAll();
         });
     }
 
@@ -275,10 +275,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.stop();
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to stop service");
             }
+            invalidateAll();
         });
     }
 
@@ -287,10 +287,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.skip();
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to skip current track");
             }
+            invalidateAll();
         });
     }
 
@@ -299,10 +299,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.previous();
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to skip backward");
             }
+            invalidateAll();
         });
     }
 
@@ -315,10 +315,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.togglePlay();
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to toggle playback");
             }
+            invalidateAll();
         });
     }
 
@@ -329,10 +329,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.play();
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to resume playback");
             }
+            invalidateAll();
         });
     }
 
@@ -343,10 +343,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.pause();
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to pause playback");
             }
+            invalidateAll();
         });
     }
 
@@ -360,10 +360,10 @@ public class ServicePlayerController implements PlayerController {
                     mShuffled.onNext(preferenceStore.isShuffled());
                     mRepeatMode.onNext(preferenceStore.getRepeatMode());
                 });
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to update remote player preferences");
             }
+            invalidateAll();
         });
     }
 
@@ -391,17 +391,14 @@ public class ServicePlayerController implements PlayerController {
                     ListTransaction.<Song, RemoteException>send(newQueue).transmit(
                             token -> mBinding.beginLargeQueueTransaction(token),
                             (header, data) -> mBinding.sendQueueChunk(header, data),
-                            () -> {
-                                mBinding.endLargeQueueTransaction(newPosition, seed);
-                                invalidateAll();
-                            });
+                            () -> mBinding.endLargeQueueTransaction(newPosition, seed));
                 } else {
                     mBinding.setQueue(newQueue, newPosition, seed);
-                    invalidateAll();
                 }
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to set queue");
             }
+            invalidateAll();
         });
     }
 
@@ -442,10 +439,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.changeSong(newPosition);
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to change song");
             }
+            invalidateAll();
         });
     }
 
@@ -457,17 +454,14 @@ public class ServicePlayerController implements PlayerController {
                     ListTransaction.<Song, RemoteException>send(queue).transmit(
                             token -> mBinding.beginLargeQueueTransaction(token),
                             (header, data) -> mBinding.sendQueueChunk(header, data),
-                            () -> {
-                                mBinding.endLargeQueueEdit(newPosition);
-                                invalidateAll();
-                            });
+                            () -> mBinding.endLargeQueueEdit(newPosition));
                 } else {
                     mBinding.editQueue(queue, newPosition);
-                    invalidateAll();
                 }
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to edit queue");
             }
+            invalidateAll();
         });
     }
 
@@ -476,10 +470,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.queueNext(song);
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to queue next song");
             }
+            invalidateAll();
         });
     }
 
@@ -488,10 +482,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.queueNextList(songs);
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to queue next songs");
             }
+            invalidateAll();
         });
     }
 
@@ -500,10 +494,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.queueLast(song);
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to queue last song");
             }
+            invalidateAll();
         });
     }
 
@@ -512,10 +506,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.queueLastList(songs);
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to queue last songs");
             }
+            invalidateAll();
         });
     }
 
@@ -526,10 +520,10 @@ public class ServicePlayerController implements PlayerController {
         execute(() -> {
             try {
                 mBinding.seekTo(position);
-                invalidateAll();
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to seek");
             }
+            invalidateAll();
         });
     }
 
@@ -600,6 +594,7 @@ public class ServicePlayerController implements PlayerController {
                 });
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to set multi-repeat count");
+                invalidateAll();
             }
         });
     }
@@ -620,6 +615,7 @@ public class ServicePlayerController implements PlayerController {
                 });
             } catch (RemoteException exception) {
                 Timber.e(exception, "Failed to set sleep-timer end time");
+                invalidateAll();
             }
         });
     }

--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -689,8 +689,10 @@ public class ServicePlayerController implements PlayerController {
 
             if (mRetriever != null) {
                 Observable.fromCallable(mRetriever::retrieve)
+                        .subscribeOn(Schedulers.computation())
                         .map(data -> (data == null) ? mNullValue : data)
                         .map(Optional::ofNullable)
+                        .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(mSubject::onNext, throwable -> {
                             Timber.e(throwable, "Failed to fetch " + mName + " property.");
                         });

--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -392,7 +392,7 @@ public class ServicePlayerController implements PlayerController {
                             token -> mBinding.beginLargeQueueTransaction(token),
                             (header, data) -> mBinding.sendQueueChunk(header, data),
                             () -> {
-                                mBinding.endLargeQueueTransaction(false, newPosition, seed);
+                                mBinding.endLargeQueueTransaction(newPosition, seed);
                                 invalidateAll();
                             });
                 } else {
@@ -458,7 +458,7 @@ public class ServicePlayerController implements PlayerController {
                             token -> mBinding.beginLargeQueueTransaction(token),
                             (header, data) -> mBinding.sendQueueChunk(header, data),
                             () -> {
-                                mBinding.endLargeQueueTransaction(true, newPosition, 0);
+                                mBinding.endLargeQueueEdit(newPosition);
                                 invalidateAll();
                             });
                 } else {

--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
@@ -15,6 +16,7 @@ import android.os.SystemClock;
 
 import com.marverenic.music.IPlayerService;
 import com.marverenic.music.JockeyApplication;
+import com.marverenic.music.R;
 import com.marverenic.music.data.store.ImmutablePreferenceStore;
 import com.marverenic.music.data.store.MediaStoreUtil;
 import com.marverenic.music.data.store.PreferenceStore;
@@ -628,7 +630,8 @@ public class ServicePlayerController implements PlayerController {
     @Override
     public Observable<Bitmap> getArtwork() {
         if (mArtwork == null) {
-            mArtwork = BehaviorSubject.create();
+            mArtwork = BehaviorSubject.create(BitmapFactory.decodeResource(
+                    mContext.getResources(), R.drawable.art_default_xl));
 
             getNowPlaying()
                     .observeOn(Schedulers.io())


### PR DESCRIPTION
All IPC now happens off the main thread. Additionally, values are predicted to instantly update the UI where possible, instead of waiting both the initial request and IPC read for the player state to come in. These two improvements significantly reduce UI stuttering when performing long operations like changing the queue with several hundreds of songs.