### PR TITLE
Fix service launching behavior for Oreo

### DIFF
--- a/app/src/main/java/com/marverenic/music/JockeyApplication.java
+++ b/app/src/main/java/com/marverenic/music/JockeyApplication.java
@@ -2,7 +2,6 @@ package com.marverenic.music;
 
 import android.app.Application;
 import android.content.Context;
-import android.os.StrictMode;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 
@@ -22,7 +21,6 @@ public class JockeyApplication extends Application {
 
     @Override
     public void onCreate() {
-        setupStrictMode();
         super.onCreate();
 
         setupCrashlytics();
@@ -35,22 +33,6 @@ public class JockeyApplication extends Application {
     @NonNull
     protected JockeyGraph createDaggerComponent() {
         return JockeyComponentFactory.create(this);
-    }
-
-    private void setupStrictMode() {
-        if (BuildConfig.DEBUG) {
-            StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
-                    .detectDiskReads()
-                    .detectDiskWrites()
-                    .detectAll()
-                    .penaltyLog()
-                    .build());
-            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
-                    .detectLeakedSqlLiteObjects()
-                    .detectLeakedClosableObjects()
-                    .penaltyLog()
-                    .build());
-        }
     }
 
     private void setupCrashlytics() {

--- a/app/src/main/java/com/marverenic/music/player/MockPlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/MockPlayerController.java
@@ -25,6 +25,16 @@ public class MockPlayerController implements PlayerController {
     }
 
     @Override
+    public Binding bind() {
+        throw new UnsupportedOperationException("Stub!");
+    }
+
+    @Override
+    public void unbind(Binding binding) {
+        throw new UnsupportedOperationException("Stub!");
+    }
+
+    @Override
     public Observable<String> getError() {
         return Observable.never();
     }

--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -303,6 +303,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @param seed A seed to use if enabling shuffle
      */
     public void updatePreferences(ReadOnlyPreferenceStore preferencesStore, long seed) {
+        requireNotReleased();
         Timber.i("Updating preferences...");
         if (preferencesStore.isShuffled() != mShuffle) {
             setShuffle(preferencesStore.isShuffled(), seed);
@@ -355,6 +356,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @see #loadState()
      */
     public void saveState() throws IOException {
+        requireNotReleased();
         Timber.i("Saving player state");
         // Anticipate the outcome of a command so that if we're killed right after it executes,
         // we can restore to the proper state
@@ -395,6 +397,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @see #saveState()
      */
     public void loadState() {
+        requireNotReleased();
         Timber.i("Loading state...");
         Scanner scanner = null;
         try {
@@ -462,6 +465,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * Updates the metadata in the attached {@link MediaSessionCompat}
      */
     private void updateMediaSession() {
+        requireNotReleased();
         if (mMediaSession == null) {
             return;
         }
@@ -733,6 +737,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @see #pause()
      */
     public void togglePlay() {
+        requireNotReleased();
         Timber.i("Toggling playback");
         if (isPlaying()) {
             pause();
@@ -748,6 +753,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * Pauses music playback
      */
     public void pause() {
+        requireNotReleased();
         Timber.i("Pausing playback");
         if (isPlaying()) {
             mMediaPlayer.pause();
@@ -763,6 +769,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * Starts or resumes music playback
      */
     public void play() {
+        requireNotReleased();
         Timber.i("Resuming playback");
         if (!isPlaying() && getFocus()) {
             mMediaPlayer.play();
@@ -781,6 +788,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @see #setRepeat(int) to set the current repeat mode
      */
     public void skip() {
+        requireNotReleased();
         Timber.i("Skipping song");
         if (!mMediaPlayer.isComplete() && !mMediaPlayer.hasError()) {
             logPlay();
@@ -847,6 +855,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @see #setRepeat(int) to set the current repeat mode
      */
     public void skipPrevious() {
+        requireNotReleased();
         Timber.i("skipPrevious() called");
         if ((getQueuePosition() == 0 && mRepeat != REPEAT_ALL)
                 || getCurrentPosition() > SKIP_PREVIOUS_THRESHOLD
@@ -865,6 +874,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * Stops music playback
      */
     public void stop() {
+        requireNotReleased();
         Timber.i("stop() called");
         pause();
         seekTo(0);
@@ -884,6 +894,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @return The {@link Song} that is currently being played
      */
     public Song getNowPlaying() {
+        requireNotReleased();
         return mMediaPlayer.getNowPlaying();
     }
 
@@ -892,6 +903,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @see MediaPlayer#isPlaying()
      */
     public boolean isPlaying() {
+        requireNotReleased();
         return mMediaPlayer.isPlaying();
     }
 
@@ -900,6 +912,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      *         otherwise the regular queue will be returned
      */
     public List<Song> getQueue() {
+        requireNotReleased();
         // If you're using this method on the UI thread, consider replacing this method with
         // return new ArrayList<>(mMediaPlayer.getQueue());
         // to prevent components from accidentally changing the backing queue
@@ -910,6 +923,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @return The current index in the queue that is being played
      */
     public int getQueuePosition() {
+        requireNotReleased();
         return mMediaPlayer.getQueueIndex();
     }
 
@@ -917,6 +931,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @return The number of items in the current queue
      */
     public int getQueueSize() {
+        requireNotReleased();
         return mMediaPlayer.getQueueSize();
     }
 
@@ -925,6 +940,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @see MediaPlayer#getCurrentPosition()
      */
     public int getCurrentPosition() {
+        requireNotReleased();
         return mMediaPlayer.getCurrentPosition();
     }
 
@@ -933,6 +949,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @see MediaPlayer#getDuration()
      */
     public int getDuration() {
+        requireNotReleased();
         return mMediaPlayer.getDuration();
     }
 
@@ -942,6 +959,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @throws IllegalArgumentException if {@code position} is not between 0 and the queue length
      */
     public void changeSong(int position) {
+        requireNotReleased();
         Timber.i("changeSong called (position = %d)", position);
         mMediaPlayer.setQueueIndex(position);
         play();
@@ -955,6 +973,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @throws IllegalArgumentException if {@code index} is not between 0 and the queue length
      */
     public void setQueue(@NonNull List<Song> queue, int index, long seed) {
+        requireNotReleased();
         Timber.i("setQueue called (%d songs)", queue.size());
         // If you're using this method on the UI thread, consider replacing the first line in this
         // method with "mQueue = new ArrayList<>(queue);"
@@ -978,6 +997,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @param index The index of the song that is currently playing in the modified queue
      */
     public void editQueue(@NonNull List<Song> queue, int index) {
+        requireNotReleased();
         Timber.i("editQueue called (index = %d)", index);
         if (mShuffle) {
             mQueueShuffled = Collections.unmodifiableList(queue);
@@ -1017,6 +1037,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      *               {@link #REPEAT_NONE}, {@link #REPEAT_ALL}, {@link #REPEAT_ONE}.
      */
     public void setRepeat(int repeat) {
+        requireNotReleased();
         Timber.i("Changing repeat setting to %d", repeat);
         mRepeat = repeat;
         switch (repeat) {
@@ -1040,6 +1061,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      *         {@link #REPEAT_NONE}, {@link #REPEAT_ALL}, or {@link #REPEAT_ONE}.
      */
     public int getRepeatMode() {
+        requireNotReleased();
         return mRepeat;
     }
 
@@ -1054,6 +1076,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      *              Repeat none.
      */
     public void setMultiRepeat(int count) {
+        requireNotReleased();
         Timber.i("Changing Multi-Repeat counter to %d", count);
         mMultiRepeat = count;
         mRemotePreferenceStore.setMultiRepeatCount(count);
@@ -1071,6 +1094,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      *         will return {@code 0}.
      */
     public int getMultiRepeatCount() {
+        requireNotReleased();
         return mMultiRepeat;
     }
 
@@ -1080,6 +1104,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      *                             Unix epoch as returned by {@link System#currentTimeMillis()}.
      */
     public void setSleepTimer(long endTimestampInMillis) {
+        requireNotReleased();
         Timber.i("Changing sleep timer end time to %d", endTimestampInMillis);
         startSleepTimer(endTimestampInMillis);
         mRemotePreferenceStore.setSleepTimerEndTime(endTimestampInMillis);
@@ -1121,6 +1146,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      *         method returns {@code 0} if the sleep timer is disabled.
      */
     public long getSleepTimerEndTime() {
+        requireNotReleased();
         return mRemotePreferenceStore.getSleepTimerEndTime();
     }
 
@@ -1132,6 +1158,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @param seed A seed to use when shuffling (only used if shuffle is {@code true})
      */
     public void setShuffle(boolean shuffle, long seed) {
+        requireNotReleased();
         if (shuffle == mShuffle) {
             return;
         }
@@ -1161,6 +1188,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @param song the song to enqueue
      */
     public void queueNext(Song song) {
+        requireNotReleased();
         Timber.i("queueNext(Song) called");
         int index = mQueue.isEmpty() ? 0 : mMediaPlayer.getQueueIndex() + 1;
 
@@ -1185,6 +1213,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @param songs The songs to enqueue
      */
     public void queueNext(List<Song> songs) {
+        requireNotReleased();
         Timber.i("queueNext(List<Song>) called");
         int index = mQueue.isEmpty() ? 0 : mMediaPlayer.getQueueIndex() + 1;
 
@@ -1209,6 +1238,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @param song The song to enqueue
      */
     public void queueLast(Song song) {
+        requireNotReleased();
         Timber.i("queueLast(Song) called");
 
         List<Song> shuffledQueue = new ArrayList<>(mQueueShuffled);
@@ -1232,6 +1262,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * @param songs The songs to enqueue
      */
     public void queueLast(List<Song> songs) {
+        requireNotReleased();
         Timber.i("queueLast(List<Song>)");
 
         List<Song> shuffledQueue = new ArrayList<>(mQueueShuffled);
@@ -1255,6 +1286,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      * Once this is called, this MusicPlayer can no longer be used.
      */
     public void release() {
+        requireNotReleased();
         Timber.i("release() called");
         AudioManagerCompat.getInstance(mContext).abandonAudioFocus(this);
         mContext.unregisterReceiver(mHeadphoneListener);
@@ -1264,11 +1296,20 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
 
         mFocused = false;
         mCallback = null;
-        mMediaPlayer.stop();
         mMediaPlayer.release();
         mMediaSession.release();
         mMediaPlayer = null;
         mContext = null;
+    }
+
+    public boolean isReleased() {
+        return mMediaPlayer == null;
+    }
+
+    private void requireNotReleased() {
+        if (isReleased()) {
+            throw new IllegalStateException("MusicPlayer has been released");
+        }
     }
 
     protected MediaSessionCompat getMediaSession() {

--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -1355,7 +1355,9 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
                 }, throwable -> {
                     Timber.e(throwable, "Failed to load artwork");
                     mArtwork = null;
-                    updateNowPlaying();
+                    if (!isReleased()) {
+                        updateNowPlaying();
+                    }
                 });
 
         updateUi();
@@ -1454,6 +1456,8 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
         }
 
         private final Runnable mButtonHandler = () -> {
+            if (mMusicPlayer.isReleased()) return;
+
             if (mClickCount == 1) {
                 mMusicPlayer.togglePlay();
                 mMusicPlayer.updateUi();
@@ -1486,36 +1490,48 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
 
         @Override
         public void onPlay() {
+            if (mMusicPlayer.isReleased()) return;
+
             mMusicPlayer.play();
             mMusicPlayer.updateUi();
         }
 
         @Override
         public void onSkipToQueueItem(long id) {
+            if (mMusicPlayer.isReleased()) return;
+
             mMusicPlayer.changeSong((int) id);
             mMusicPlayer.updateUi();
         }
 
         @Override
         public void onPause() {
+            if (mMusicPlayer.isReleased()) return;
+
             mMusicPlayer.pause();
             mMusicPlayer.updateUi();
         }
 
         @Override
         public void onSkipToNext() {
+            if (mMusicPlayer.isReleased()) return;
+
             mMusicPlayer.skip();
             mMusicPlayer.updateUi();
         }
 
         @Override
         public void onSkipToPrevious() {
+            if (mMusicPlayer.isReleased()) return;
+
             mMusicPlayer.skipPrevious();
             mMusicPlayer.updateUi();
         }
 
         @Override
         public void onStop() {
+            if (mMusicPlayer.isReleased()) return;
+
             mMusicPlayer.stop();
             // Don't update the UI if this object has been released
             if (mMusicPlayer.mContext != null) {
@@ -1525,12 +1541,16 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
 
         @Override
         public void onSeekTo(long pos) {
+            if (mMusicPlayer.isReleased()) return;
+
             mMusicPlayer.seekTo((int) pos);
             mMusicPlayer.updateUi();
         }
 
         @Override
         public void onSetRepeatMode(int repeatMode) {
+            if (mMusicPlayer.isReleased()) return;
+
             switch (repeatMode) {
                 case PlaybackStateCompat.REPEAT_MODE_ALL:
                     mMusicPlayer.setRepeat(REPEAT_ALL);
@@ -1546,6 +1566,8 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
 
         @Override
         public void onSetShuffleMode(int shuffleMode) {
+            if (mMusicPlayer.isReleased()) return;
+
             switch (shuffleMode) {
                 case PlaybackStateCompat.SHUFFLE_MODE_ALL:
                     mMusicPlayer.setShuffle(true, System.currentTimeMillis());

--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -1038,6 +1038,10 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
      */
     public void setRepeat(int repeat) {
         requireNotReleased();
+        if (repeat == mRepeat) {
+            return;
+        }
+
         Timber.i("Changing repeat setting to %d", repeat);
         mRepeat = repeat;
         switch (repeat) {

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -11,7 +11,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.IBinder;
-import android.os.Process;
 import android.os.RemoteException;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.StringRes;
@@ -53,7 +52,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     /**
      * Used in binding and unbinding this service to the UI process
      */
-    private static IBinder binder;
+    private IBinder mBinder;
 
     // Instance variables
     /**
@@ -86,10 +85,10 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     public IBinder onBind(Intent intent) {
         Timber.i("onBind called");
 
-        if (binder == null) {
-            binder = new Stub(this);
+        if (mBinder == null) {
+            mBinder = new Stub(this);
         }
-        return binder;
+        return mBinder;
     }
 
     /**
@@ -138,17 +137,6 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     public void onDestroy() {
         Timber.i("Called onDestroy");
         finish();
-
-        /*
-            By default, when this service stops, Android will keep a cached version of it so it can
-            be restarted easily. When this happens, the service enters a state where the main app
-            can no longer bind to it when it is started the next time. We therefore prevent this
-            entirely by not allowing Android to keep the service process cached.
-
-            This is a VERY bad idea, so make sure that this service always has its own process, and
-            make sure to be very careful about cleaning up all resources before this method returns.
-         */
-        Process.killProcess(Process.myPid());
     }
 
     @Override

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -383,7 +383,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void stop() throws RemoteException {
+        public void stop() {
             try {
                 mService.stop();
             } catch (RuntimeException exception) {
@@ -393,7 +393,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void skip() throws RemoteException {
+        public void skip() {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.skip(): Service is not ready. Dropping command");
                 return;
@@ -408,7 +408,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void previous() throws RemoteException {
+        public void previous() {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.skip(): Service is not ready. Dropping command");
                 return;
@@ -423,7 +423,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void togglePlay() throws RemoteException {
+        public void togglePlay() {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.togglePlay(): Service is not ready. Dropping command");
                 return;
@@ -438,7 +438,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void play() throws RemoteException {
+        public void play() {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.play(): Service is not ready. Dropping command");
                 return;
@@ -453,7 +453,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void pause() throws RemoteException {
+        public void pause() {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.pause(): Service is not ready. Dropping command");
                 return;
@@ -468,7 +468,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void setPreferences(ImmutablePreferenceStore preferences, long seed) throws RemoteException {
+        public void setPreferences(ImmutablePreferenceStore preferences, long seed) {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.setPreferences(): Service is not ready. Dropping command");
                 return;
@@ -483,7 +483,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void setQueue(List<Song> newQueue, int newPosition, long seed) throws RemoteException {
+        public void setQueue(List<Song> newQueue, int newPosition, long seed) {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.setQueue(): Service is not ready. Dropping command");
                 return;
@@ -501,7 +501,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void beginLargeQueueTransaction(TransactionToken token) throws RemoteException {
+        public void beginLargeQueueTransaction(TransactionToken token) {
             if (mQueueTransaction != null) {
                 Timber.i("LargeQueueTransaction is already open. Dropping previous transaction.");
             }
@@ -509,7 +509,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void sendQueueChunk(ChunkHeader header, List<Song> chunk) throws RemoteException {
+        public void sendQueueChunk(ChunkHeader header, List<Song> chunk) {
             mQueueTransaction.receive(header, chunk);
         }
 
@@ -540,7 +540,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void changeSong(int position) throws RemoteException {
+        public void changeSong(int position) {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.changeSong(): Service is not ready. Dropping command");
                 return;
@@ -555,7 +555,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void editQueue(List<Song> newQueue, int newPosition) throws RemoteException {
+        public void editQueue(List<Song> newQueue, int newPosition) {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.editQueue(): Service is not ready. Dropping command");
                 return;
@@ -570,7 +570,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void queueNext(Song song) throws RemoteException {
+        public void queueNext(Song song) {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.queueNext(): Service is not ready. Dropping command");
                 return;
@@ -585,7 +585,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void queueNextList(List<Song> songs) throws RemoteException {
+        public void queueNextList(List<Song> songs) {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.queueNextList(): Service is not ready. Dropping command");
                 return;
@@ -600,7 +600,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void queueLast(Song song) throws RemoteException {
+        public void queueLast(Song song) {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.queueLast(): Service is not ready. Dropping command");
                 return;
@@ -615,7 +615,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void queueLastList(List<Song> songs) throws RemoteException {
+        public void queueLastList(List<Song> songs) {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.queueLastList(): Service is not ready. Dropping command");
                 return;
@@ -630,7 +630,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void seekTo(int position) throws RemoteException {
+        public void seekTo(int position) {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.seekTo(): Service is not ready. Dropping command");
                 return;
@@ -645,7 +645,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public boolean isPlaying() throws RemoteException {
+        public boolean isPlaying() {
             if (!isMusicPlayerReady()) {
                 return false;
             }
@@ -659,7 +659,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public Song getNowPlaying() throws RemoteException {
+        public Song getNowPlaying() {
             if (!isMusicPlayerReady()) {
                 return null;
             }
@@ -673,7 +673,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public List<Song> getQueue() throws RemoteException {
+        public List<Song> getQueue() {
             if (!isMusicPlayerReady()) {
                 return Collections.emptyList();
             }
@@ -687,7 +687,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public int getQueuePosition() throws RemoteException {
+        public int getQueuePosition() {
             if (!isMusicPlayerReady()) {
                 return 0;
             }
@@ -701,7 +701,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public int getQueueSize() throws RemoteException {
+        public int getQueueSize() {
             if (!isMusicPlayerReady()) {
                 return 0;
             }
@@ -735,7 +735,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public int getCurrentPosition() throws RemoteException {
+        public int getCurrentPosition() {
             if (!isMusicPlayerReady()) {
                 return 0;
             }
@@ -749,7 +749,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public int getDuration() throws RemoteException {
+        public int getDuration() {
             if (!isMusicPlayerReady()) {
                 return 0;
             }
@@ -763,7 +763,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public PlayerState getPlayerState() throws RemoteException {
+        public PlayerState getPlayerState() {
             if (!isMusicPlayerReady()) {
                 return null;
             }
@@ -777,7 +777,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void restorePlayerState(PlayerState state) throws RemoteException {
+        public void restorePlayerState(PlayerState state) {
             if (!isMusicPlayerReady()) {
                 Timber.i("restorePlayerState(): Service is not ready. Dropping command");
                 return;
@@ -792,7 +792,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public int getMultiRepeatCount() throws RemoteException {
+        public int getMultiRepeatCount() {
             if (!isMusicPlayerReady()) {
                 return 0;
             }
@@ -806,7 +806,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void setMultiRepeatCount(int count) throws RemoteException {
+        public void setMultiRepeatCount(int count) {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.setMultiRepeat(): Service is not ready. Dropping command");
                 return;
@@ -839,7 +839,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public long getSleepTimerEndTime() throws RemoteException {
+        public long getSleepTimerEndTime() {
             if (!isMusicPlayerReady()) {
                 return 0;
             }
@@ -853,7 +853,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public void setSleepTimerEndTime(long timestampInMillis) throws RemoteException {
+        public void setSleepTimerEndTime(long timestampInMillis) {
             if (!isMusicPlayerReady()) {
                 Timber.i("PlayerService.setSleepTimer(): Service is not ready. Dropping command");
                 return;
@@ -867,7 +867,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         @Override
-        public MediaSessionCompat.Token getMediaSessionToken() throws RemoteException {
+        public MediaSessionCompat.Token getMediaSessionToken() {
             if (!isMusicPlayerReady()) {
                 return null;
             }

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -79,7 +79,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     @Override
     public IBinder onBind(Intent intent) {
         Timber.i("onBind called");
-        return new Stub(this);
+        return new PlayerServiceBinder(this);
     }
 
     /**
@@ -369,12 +369,12 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         notifyNowPlaying();
     }
 
-    public static class Stub extends IPlayerService.Stub {
+    public static class PlayerServiceBinder extends IPlayerService.Stub {
 
         private PlayerService mService;
         private IncomingTransaction<List<Song>> mQueueTransaction;
 
-        public Stub(PlayerService service) {
+        PlayerServiceBinder(PlayerService service) {
             mService = service;
         }
 

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -49,11 +49,6 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     private static final String NOTIFICATION_CHANNEL_ID = "music-service";
     private static final int NOTIFICATION_ID = 1;
 
-    /**
-     * Used in binding and unbinding this service to the UI process
-     */
-    private IBinder mBinder;
-
     // Instance variables
     /**
      * The media player for the service instance
@@ -84,11 +79,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     @Override
     public IBinder onBind(Intent intent) {
         Timber.i("onBind called");
-
-        if (mBinder == null) {
-            mBinder = new Stub(this);
-        }
-        return mBinder;
+        return new Stub(this);
     }
 
     /**

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -826,11 +826,19 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
         @Override
         public boolean getShuffleMode() {
+            if (!isMusicPlayerReady()) {
+                return false;
+            }
+
             return mService.musicPlayer.isShuffled();
         }
 
         @Override
         public int getRepeatMode() {
+            if (!isMusicPlayerReady()) {
+                return MusicPlayer.REPEAT_NONE;
+            }
+
             return mService.musicPlayer.getRepeatMode();
         }
 

--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -231,6 +231,7 @@ public class ServicePlayerController implements PlayerController {
         mSleepTimerEndTime.setFunction(null);
         mShuffleMode.setFunction(null);
         mRepeatMode.setFunction(null);
+        mMediaSessionToken.onNext(null);
     }
 
     private void initAllProperties() {

--- a/app/src/main/java/com/marverenic/music/player/browser/JockeyBrowserService.java
+++ b/app/src/main/java/com/marverenic/music/player/browser/JockeyBrowserService.java
@@ -30,6 +30,7 @@ public class JockeyBrowserService extends MediaBrowserServiceCompat {
 
     @Override
     public void onCreate() {
+        Timber.i("Browser service created");
         super.onCreate();
         JockeyApplication.getComponent(this).inject(this);
 
@@ -43,6 +44,7 @@ public class JockeyBrowserService extends MediaBrowserServiceCompat {
 
     @Override
     public void onDestroy() {
+        Timber.i("Browser service destroyed");
         super.onDestroy();
         mPlayerController.unbind(mPlayerControllerBinding);
         mMediaSessionSubscription.unsubscribe();

--- a/app/src/main/java/com/marverenic/music/player/browser/JockeyBrowserService.java
+++ b/app/src/main/java/com/marverenic/music/player/browser/JockeyBrowserService.java
@@ -24,6 +24,7 @@ public class JockeyBrowserService extends MediaBrowserServiceCompat {
     @Inject MediaBrowserRoot mRoot;
     @Inject EmptyBrowserRoot mEmptyRoot;
 
+    private PlayerController.Binding mPlayerControllerBinding;
     private BrowserServicePackageValidator mPackageValidator;
     private Subscription mMediaSessionSubscription;
 
@@ -33,6 +34,7 @@ public class JockeyBrowserService extends MediaBrowserServiceCompat {
         JockeyApplication.getComponent(this).inject(this);
 
         mPackageValidator = new BrowserServicePackageValidator(this);
+        mPlayerControllerBinding = mPlayerController.bind();
         mMediaSessionSubscription = mPlayerController.getMediaSessionToken()
                 .subscribe(this::setSessionToken, e -> {
                     Timber.e(e, "Failed to post media session token");
@@ -42,9 +44,8 @@ public class JockeyBrowserService extends MediaBrowserServiceCompat {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        if (mMediaSessionSubscription != null) {
-            mMediaSessionSubscription.unsubscribe();
-        }
+        mPlayerController.unbind(mPlayerControllerBinding);
+        mMediaSessionSubscription.unsubscribe();
     }
 
     @Nullable

--- a/app/src/main/java/com/marverenic/music/player/browser/JockeyBrowserService.java
+++ b/app/src/main/java/com/marverenic/music/player/browser/JockeyBrowserService.java
@@ -37,6 +37,7 @@ public class JockeyBrowserService extends MediaBrowserServiceCompat {
         mPackageValidator = new BrowserServicePackageValidator(this);
         mPlayerControllerBinding = mPlayerController.bind();
         mMediaSessionSubscription = mPlayerController.getMediaSessionToken()
+                .first()
                 .subscribe(this::setSessionToken, e -> {
                     Timber.e(e, "Failed to post media session token");
                 });

--- a/app/src/main/java/com/marverenic/music/ui/BaseActivity.java
+++ b/app/src/main/java/com/marverenic/music/ui/BaseActivity.java
@@ -47,6 +47,8 @@ public abstract class BaseActivity extends RxAppCompatActivity {
     @Inject ThemeStore _mThemeStore;
     @Inject PlayerController _mPlayerController;
 
+    private PlayerController.Binding mPlayerControllerBinding;
+
     /**
      * @inheritDoc
      */
@@ -104,6 +106,12 @@ public abstract class BaseActivity extends RxAppCompatActivity {
                 .show();
     }
 
+    @Override
+    protected void onStart() {
+        super.onStart();
+        mPlayerControllerBinding = _mPlayerController.bind();
+    }
+
     /**
      * @inheritDoc
      */
@@ -125,6 +133,13 @@ public abstract class BaseActivity extends RxAppCompatActivity {
                 || (mBackgroundColor == AppCompatDelegate.MODE_NIGHT_AUTO && nightDiff)) {
             recreate();
         }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        _mPlayerController.unbind(mPlayerControllerBinding);
+        mPlayerControllerBinding = null;
     }
 
     @Override

--- a/app/src/main/java/com/marverenic/music/utils/RxProperty.java
+++ b/app/src/main/java/com/marverenic/music/utils/RxProperty.java
@@ -1,0 +1,75 @@
+package com.marverenic.music.utils;
+
+import rx.Observable;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
+import rx.subjects.BehaviorSubject;
+import timber.log.Timber;
+
+public final class RxProperty<T> {
+
+    private final String mName;
+    private final T mNullValue;
+    private final BehaviorSubject<Optional<T>> mSubject;
+    private final Observable<T> mObservable;
+
+    private Retriever<T> mRetriever;
+
+    public RxProperty(String propertyName) {
+        this(propertyName, null);
+    }
+
+    public RxProperty(String propertyName, T nullValue) {
+        mName = propertyName;
+        mNullValue = nullValue;
+        mSubject = BehaviorSubject.create();
+
+        mObservable = mSubject.filter(Optional::isPresent)
+                .map(Optional::getValue)
+                .distinctUntilChanged();
+    }
+
+    public void setFunction(Retriever<T> retriever) {
+        mRetriever = retriever;
+    }
+
+    public void invalidate() {
+        mSubject.onNext(Optional.empty());
+
+        if (mRetriever != null) {
+            Observable.fromCallable(mRetriever::retrieve)
+                    .subscribeOn(Schedulers.computation())
+                    .map(data -> (data == null) ? mNullValue : data)
+                    .map(Optional::ofNullable)
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(mSubject::onNext, throwable -> {
+                        Timber.e(throwable, "Failed to fetch " + mName + " property.");
+                    });
+        }
+    }
+
+    public boolean isSubscribedTo() {
+        return mSubject.hasObservers();
+    }
+
+    public void setValue(T value) {
+        mSubject.onNext(Optional.ofNullable(value));
+    }
+
+    public boolean hasValue() {
+        return mSubject.getValue() != null && mSubject.getValue().isPresent();
+    }
+
+    public T lastValue() {
+        return mSubject.getValue().getValue();
+    }
+
+    public Observable<T> getObservable() {
+        return mObservable;
+    }
+
+    public interface Retriever<T> {
+        T retrieve() throws Exception;
+    }
+
+}

--- a/app/src/main/java/com/marverenic/music/widget/BaseWidget.java
+++ b/app/src/main/java/com/marverenic/music/widget/BaseWidget.java
@@ -34,7 +34,9 @@ public abstract class BaseWidget extends AppWidgetProvider {
     @Override
     public final void onUpdate(Context context, AppWidgetManager widgetManager, int[] widgetIds) {
         if (isEnabled(context)) {
+            PlayerController.Binding binding = mPlayerController.bind();
             onUpdate(context);
+            mPlayerController.unbind(binding);
         }
     }
 


### PR DESCRIPTION
Android O introduces a number of new [background execution limits for services](https://developer.android.com/about/versions/oreo/background#services). In particular, there is a restriction that a background application cannot start services (if it attempts to, an `IllegalStateException` will be thrown). One notable exception to this is that bound services are exempt from these limits.

In several cases, Jockey needs to be able to start the playback service from a stopped state. The most notable is for Android Auto, where the screen may not even be on when the service needs to start. This wouldn't normally be an issue because Jockey does use a bound service, except that the mechanism for starting the service was pretty hacky. It was previously started as a regular service, and then immediately bound to instead of using the `BIND_AUTO_CREATE` flag. Despite this service being used as a bound service, it was not started as one and therefore is subject to the new background execution limits.

To properly manage bound services, Jockey now starts its player service using the `BIND_AUTO_CREATE` flag. This comes with the caveat that the binding must be released when no components (generally activities) need access to the service, otherwise the service will be restarted over and over until Jockey is force stopped. To generalize this behavior, `PlayerController` now has the concept of a `Binding` – a token representing that a component is active and that the connection to the player service should remain open. As long as one or more `Binding`s are active, the service will remain bound. Likewise, as soon as the last `Binding` is released, the service will be unbound (but not necessarily killed). If another `Binding` is requested, then the service will be rebound, using an existing instance of the service if possible. This abstraction is in-line with samples from Google on using bound services.

Also note that many of the additions here are simply safety or logging mechanisms added during the process of ~~~pulling my hair out~~~ debugging.