### PR TITLE
Allow recently added and browser page to be the default page

### DIFF
--- a/app/src/main/java/com/marverenic/music/data/annotations/StartPage.java
+++ b/app/src/main/java/com/marverenic/music/data/annotations/StartPage.java
@@ -3,11 +3,13 @@ package com.marverenic.music.data.annotations;
 import android.support.annotation.IntDef;
 
 @IntDef(value = {StartPage.PLAYLISTS, StartPage.SONGS, StartPage.ARTISTS, StartPage.ALBUMS,
-        StartPage.GENRES})
+        StartPage.GENRES, StartPage.BROWSER, StartPage.RECENTLY_ADDED})
 public @interface StartPage {
     int PLAYLISTS = 0;
     int SONGS = 1;
     int ARTISTS = 2;
     int ALBUMS = 3;
     int GENRES = 4;
+    int BROWSER = 5;
+    int RECENTLY_ADDED = 6;
 }

--- a/app/src/main/java/com/marverenic/music/ui/SingleFragmentActivity.java
+++ b/app/src/main/java/com/marverenic/music/ui/SingleFragmentActivity.java
@@ -65,6 +65,7 @@ public abstract class SingleFragmentActivity extends BaseActivity {
      * to this activity.
      */
     protected Fragment getContentFragment() {
+        getSupportFragmentManager().executePendingTransactions();
         return getSupportFragmentManager().findFragmentByTag(CONTENT_FRAGMENT_TAG);
     }
 

--- a/app/src/main/java/com/marverenic/music/ui/library/LibraryActivity.java
+++ b/app/src/main/java/com/marverenic/music/ui/library/LibraryActivity.java
@@ -75,11 +75,13 @@ public class LibraryActivity extends BaseLibraryActivity {
 
         onNewIntent(getIntent());
 
-        if (savedInstanceState == null) {
-            setSelectedPage(R.id.menu_library_home);
+        Fragment fragment = getContentFragment();
+        if (fragment instanceof MusicBrowserFragment) {
+            setSelectedPage(R.id.menu_library_browse);
+        } else if (fragment instanceof RecentlyAddedFragment) {
+            setSelectedPage(R.id.menu_library_recently_added);
         } else {
-            int savedPage = savedInstanceState.getInt(EXTRA_SAVED_PAGE_ID, R.id.menu_library_home);
-            setSelectedPage(savedPage);
+            setSelectedPage(R.id.menu_library_home);
         }
     }
 

--- a/app/src/main/java/com/marverenic/music/ui/library/LibraryViewModel.java
+++ b/app/src/main/java/com/marverenic/music/ui/library/LibraryViewModel.java
@@ -7,6 +7,7 @@ import android.support.v4.app.FragmentPagerAdapter;
 
 import com.marverenic.music.BR;
 import com.marverenic.music.R;
+import com.marverenic.music.data.annotations.StartPage;
 import com.marverenic.music.data.store.PreferenceStore;
 import com.marverenic.music.data.store.ThemeStore;
 import com.marverenic.music.ui.BaseViewModel;
@@ -33,7 +34,12 @@ public class LibraryViewModel extends BaseViewModel {
         mFragmentManager = fragmentManager;
         mThemeStore = themeStore;
 
-        setPage(preferenceStore.getDefaultPage());
+        int startingPage = preferenceStore.getDefaultPage();
+        if (startingPage < StartPage.PLAYLISTS || startingPage > StartPage.GENRES) {
+            startingPage = StartPage.SONGS;
+        }
+
+        setPage(startingPage);
         mPagerAdapter = new LibraryPagerAdapter(getContext(), fragmentManager);
     }
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -244,6 +244,7 @@
     <string name="pref_category_library">Biblioteca</string>
     <string name="playback_header">Reproducción</string>
     <string name="default_page_pref">Página por Defecto</string>
+    <string name="pref_header_browser_page">Navegador de Música</string>
     <string name="theme_primary">Color Primario</string>
     <string name="theme_accent">Color del Acento</string>
     <string name="theme_base">Color de Fondo</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -10,6 +10,8 @@
         <item>@string/header_artists</item>
         <item>@string/header_albums</item>
         <item>@string/header_genres</item>
+        <item>@string/pref_header_browser_page</item>
+        <item>@string/header_recently_added</item>
     </string-array>
     <string-array name="page_values">
         <item>0</item>
@@ -17,6 +19,8 @@
         <item>2</item>
         <item>3</item>
         <item>4</item>
+        <item>5</item>
+        <item>6</item>
     </string-array>
     <string-array name="colors">
         <item>@string/color_grey</item>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -23,6 +23,7 @@
     <dimen name="now_playing_button_size">42dp</dimen>
     <dimen name="widget_button_size">36dp</dimen>
     <dimen name="now_playing_max_control_width">400dp</dimen>
+    <dimen name="now_playing_control_min_width">0dp</dimen>
     <item name="now_playing_control_end_weight" format="float" type="dimen">0.6</item>
     <dimen name="breadcrumb_toolbar_horizontal_padding">16dp</dimen>
     <dimen name="fab_margin">16dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -262,6 +262,7 @@
     <string name="pref_category_library">Library</string>
     <string name="playback_header">Playback</string>
     <string name="default_page_pref">Default Page</string>
+    <string name="pref_header_browser_page">Music Browser</string>
     <string name="theme_primary">Primary Color</string>
     <string name="theme_accent">Accent Color</string>
     <string name="theme_base">Background Color</string>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     //noinspection GroovyAssignabilityCheck
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu May 10 13:11:33 EDT 2018
+#Tue Nov 06 19:26:01 EST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
This PR updates the setting for the default page in Jockey to be set to the recently added or the music browser page in addition to any of the tabs in the library page. If the library page is opened with either of these initial pages set, the library page will be opened to the songs tabs.