### PR TITLE
Fix widgets not updating when Jockey is not in the foreground

### DIFF
--- a/app/src/main/java/com/marverenic/music/widget/BaseWidget.java
+++ b/app/src/main/java/com/marverenic/music/widget/BaseWidget.java
@@ -34,9 +34,7 @@ public abstract class BaseWidget extends AppWidgetProvider {
     @Override
     public final void onUpdate(Context context, AppWidgetManager widgetManager, int[] widgetIds) {
         if (isEnabled(context)) {
-            PlayerController.Binding binding = mPlayerController.bind();
             onUpdate(context);
-            mPlayerController.unbind(binding);
         }
     }
 

--- a/app/src/main/java/com/marverenic/music/widget/CompactWidget.java
+++ b/app/src/main/java/com/marverenic/music/widget/CompactWidget.java
@@ -9,8 +9,9 @@ import android.support.v4.content.ContextCompat;
 import android.widget.RemoteViews;
 
 import com.marverenic.music.R;
-import com.marverenic.music.ui.library.LibraryActivity;
 import com.marverenic.music.model.Song;
+import com.marverenic.music.player.PlayerController;
+import com.marverenic.music.ui.library.LibraryActivity;
 import com.marverenic.music.utils.MediaStyleHelper;
 
 import rx.Observable;
@@ -24,13 +25,15 @@ public class CompactWidget extends BaseWidget {
 
     @Override
     protected void onUpdate(Context context) {
+        PlayerController.Binding binding = mPlayerController.bind();
         Observable.just(createBaseView(context))
                 .flatMap(views -> mPlayerController.getNowPlaying().take(1)
                         .map(song -> setSong(context, views, song)))
                 .flatMap(views -> mPlayerController.isPlaying().take(1)
                         .map(isPlaying -> setPlaying(views, isPlaying)))
                 .subscribe(views -> updateAllInstances(context, views),
-                        throwable -> Timber.e(throwable, "Failed to update widget"));
+                        throwable -> Timber.e(throwable, "Failed to update widget"),
+                        () -> mPlayerController.unbind(binding));
     }
 
     private RemoteViews createBaseView(Context context) {

--- a/app/src/main/java/com/marverenic/music/widget/SquareWidget.java
+++ b/app/src/main/java/com/marverenic/music/widget/SquareWidget.java
@@ -8,8 +8,9 @@ import android.support.annotation.Nullable;
 import android.widget.RemoteViews;
 
 import com.marverenic.music.R;
-import com.marverenic.music.ui.library.LibraryActivity;
 import com.marverenic.music.model.Song;
+import com.marverenic.music.player.PlayerController;
+import com.marverenic.music.ui.library.LibraryActivity;
 import com.marverenic.music.utils.MediaStyleHelper;
 
 import rx.Observable;
@@ -23,6 +24,7 @@ public class SquareWidget extends BaseWidget {
 
     @Override
     protected void onUpdate(Context context) {
+        PlayerController.Binding binding = mPlayerController.bind();
         Observable.just(createBaseView(context))
                 .flatMap(views -> mPlayerController.getNowPlaying().take(1)
                         .map(song -> setSong(context, views, song)))
@@ -31,7 +33,8 @@ public class SquareWidget extends BaseWidget {
                 .flatMap(views -> mPlayerController.getArtwork().take(1)
                         .map(artwork -> setArtwork(views, artwork)))
                 .subscribe(views -> updateAllInstances(context, views),
-                        throwable -> Timber.e(throwable, "Failed to update widget"));
+                        throwable -> Timber.e(throwable, "Failed to update widget"),
+                        () -> mPlayerController.unbind(binding));
     }
 
     private RemoteViews createBaseView(Context context) {

--- a/app/src/main/java/com/marverenic/music/widget/WideWidget.java
+++ b/app/src/main/java/com/marverenic/music/widget/WideWidget.java
@@ -10,8 +10,9 @@ import android.support.v4.content.ContextCompat;
 import android.widget.RemoteViews;
 
 import com.marverenic.music.R;
-import com.marverenic.music.ui.library.LibraryActivity;
 import com.marverenic.music.model.Song;
+import com.marverenic.music.player.PlayerController;
+import com.marverenic.music.ui.library.LibraryActivity;
 import com.marverenic.music.utils.MediaStyleHelper;
 
 import rx.Observable;
@@ -25,6 +26,7 @@ public class WideWidget extends BaseWidget {
 
     @Override
     protected void onUpdate(Context context) {
+        PlayerController.Binding binding = mPlayerController.bind();
         Observable.just(createBaseView(context))
                 .flatMap(views -> mPlayerController.getNowPlaying().take(1)
                         .map(song -> setSong(context, views, song)))
@@ -33,7 +35,8 @@ public class WideWidget extends BaseWidget {
                 .flatMap(views -> mPlayerController.getArtwork().take(1)
                         .map(artwork -> setArtwork(views, artwork)))
                 .subscribe(views -> updateAllInstances(context, views),
-                        throwable -> Timber.e(throwable, "Failed to update widget"));
+                        throwable -> Timber.e(throwable, "Failed to update widget"),
+                        () -> mPlayerController.unbind(binding));
     }
 
     private RemoteViews createBaseView(Context context) {


### PR DESCRIPTION
The previous implementation Jockey's widgets has a race condition: the player controller's binding is released before data could be fetched from the remote service. This causes the remote binding to be released and the widget to never update unless another component was bound to the service.

The fix for this issue is to wait until widgets' subscriptions return a value before unbinding from the remote service.