### PR TITLE
Fix media button PendingIntents being ignored on pre-L devices

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -307,6 +307,8 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
         Timber.i("Initializing MediaSession");
         ComponentName mbrComponent = new ComponentName(mContext, MediaButtonReceiver.class.getName());
         mMediaSession = new MediaSessionCompat(mContext, TAG, mbrComponent, null);
+        mMediaSession.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS
+                | MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS);
 
         mMediaSession.setCallback(new MediaSessionCallback(this, mMediaBrowserRoot));
         mMediaSession.setSessionActivity(

--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -763,7 +763,9 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
         requireNotReleased();
         Timber.i("stop() called");
         pause();
-        seekTo(0);
+        if (mCallback != null) {
+            mCallback.onPlaybackStop();
+        }
     }
 
     /**
@@ -1323,6 +1325,14 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
          * {@link MediaPlayer} changes states.
          */
         void onPlaybackChange();
+
+        /**
+         * Called when a MusicPlayer stops playback. This method will always be called, even if the
+         * event was caused by an external source. This method should be implemented to handle
+         * any side effects of a MusicPlayer being stopped, which may happen due to user interaction
+         * from other components of the system.
+         */
+        void onPlaybackStop();
     }
 
     private static class MediaSessionCallback extends MediaSessionCompat.Callback {

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -18,7 +18,8 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.media.app.NotificationCompat.MediaStyle;
 import android.support.v4.media.session.MediaButtonReceiver;
 import android.support.v4.media.session.MediaSessionCompat;
-import android.view.KeyEvent;
+import android.support.v4.media.session.PlaybackStateCompat;
+import android.support.v4.media.session.PlaybackStateCompat.MediaKeyAction;
 
 import com.marverenic.music.BuildConfig;
 import com.marverenic.music.IPlayerService;
@@ -215,25 +216,25 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
     private void setupNotificationActions(NotificationCompat.Builder builder) {
         addNotificationAction(builder, R.drawable.ic_skip_previous_36dp,
-                R.string.action_previous, KeyEvent.KEYCODE_MEDIA_PREVIOUS);
+                R.string.action_previous, PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS);
 
         if (musicPlayer.isPlaying()) {
             addNotificationAction(builder, R.drawable.ic_pause_36dp,
-                    R.string.action_pause, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE);
+                    R.string.action_pause, PlaybackStateCompat.ACTION_PLAY_PAUSE);
         } else {
             addNotificationAction(builder, R.drawable.ic_play_arrow_36dp,
-                    R.string.action_play, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE);
+                    R.string.action_play, PlaybackStateCompat.ACTION_PLAY_PAUSE);
         }
 
         addNotificationAction(builder, R.drawable.ic_skip_next_36dp,
-                R.string.action_skip, KeyEvent.KEYCODE_MEDIA_NEXT);
+                R.string.action_skip, PlaybackStateCompat.ACTION_SKIP_TO_NEXT);
     }
 
     private void addNotificationAction(NotificationCompat.Builder builder,
                                        @DrawableRes int icon, @StringRes int string,
-                                       int keyEvent) {
+                                       @MediaKeyAction long action) {
 
-        PendingIntent intent = MediaStyleHelper.getActionIntent(this, keyEvent);
+        PendingIntent intent = MediaButtonReceiver.buildMediaButtonPendingIntent(this, action);
         builder.addAction(new NotificationCompat.Action(icon, getString(string), intent));
     }
 

--- a/app/src/main/java/com/marverenic/music/utils/MediaStyleHelper.java
+++ b/app/src/main/java/com/marverenic/music/utils/MediaStyleHelper.java
@@ -1,15 +1,12 @@
 package com.marverenic.music.utils;
 
-import android.app.PendingIntent;
 import android.content.Context;
-import android.content.Intent;
 import android.graphics.BitmapFactory;
+import android.support.v4.app.NotificationCompat;
 import android.support.v4.media.MediaDescriptionCompat;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.session.MediaControllerCompat;
 import android.support.v4.media.session.MediaSessionCompat;
-import android.support.v4.app.NotificationCompat;
-import android.view.KeyEvent;
 
 import com.marverenic.music.R;
 
@@ -53,21 +50,5 @@ public class MediaStyleHelper {
         }
 
         return builder;
-    }
-
-    /**
-     * Create a {@link PendingIntent} appropriate for a MediaStyle notification's action. Assumes
-     * you are using a media button receiver.
-     * @param context Context used to construct the pending intent.
-     * @param mediaKeyEvent KeyEvent code to send to your media button receiver.
-     * @return An appropriate pending intent for sending a media button to your media button
-     *      receiver.
-     */
-    public static PendingIntent getActionIntent(Context context, int mediaKeyEvent) {
-        Intent intent = new Intent(Intent.ACTION_MEDIA_BUTTON);
-        intent.setPackage(context.getPackageName());
-        intent.putExtra(Intent.EXTRA_KEY_EVENT,
-                new KeyEvent(KeyEvent.ACTION_DOWN, mediaKeyEvent));
-        return PendingIntent.getBroadcast(context, mediaKeyEvent, intent, 0);
     }
 }

--- a/app/src/main/java/com/marverenic/music/widget/BaseWidget.java
+++ b/app/src/main/java/com/marverenic/music/widget/BaseWidget.java
@@ -1,10 +1,12 @@
 package com.marverenic.music.widget;
 
+import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.support.v4.media.session.MediaButtonReceiver;
 import android.widget.RemoteViews;
 
 import com.marverenic.music.JockeyApplication;
@@ -12,6 +14,10 @@ import com.marverenic.music.player.MusicPlayer;
 import com.marverenic.music.player.PlayerController;
 
 import javax.inject.Inject;
+
+import static android.support.v4.media.session.PlaybackStateCompat.ACTION_PLAY_PAUSE;
+import static android.support.v4.media.session.PlaybackStateCompat.ACTION_SKIP_TO_NEXT;
+import static android.support.v4.media.session.PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS;
 
 public abstract class BaseWidget extends AppWidgetProvider {
 
@@ -60,5 +66,17 @@ public abstract class BaseWidget extends AppWidgetProvider {
     protected void updateAllInstances(Context context, RemoteViews delta) {
         AppWidgetManager wm = AppWidgetManager.getInstance(context);
         wm.updateAppWidget(getComponentName(context), delta);
+    }
+
+    protected PendingIntent getSkipNextIntent(Context context) {
+        return MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_NEXT);
+    }
+
+    protected PendingIntent getSkipPreviousIntent(Context context) {
+        return MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_SKIP_TO_PREVIOUS);
+    }
+
+    protected PendingIntent getPlayPauseIntent(Context context) {
+        return MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PLAY_PAUSE);
     }
 }

--- a/app/src/main/java/com/marverenic/music/widget/CompactWidget.java
+++ b/app/src/main/java/com/marverenic/music/widget/CompactWidget.java
@@ -12,14 +12,9 @@ import com.marverenic.music.R;
 import com.marverenic.music.model.Song;
 import com.marverenic.music.player.PlayerController;
 import com.marverenic.music.ui.library.LibraryActivity;
-import com.marverenic.music.utils.MediaStyleHelper;
 
 import rx.Observable;
 import timber.log.Timber;
-
-import static android.view.KeyEvent.KEYCODE_MEDIA_NEXT;
-import static android.view.KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE;
-import static android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS;
 
 public class CompactWidget extends BaseWidget {
 
@@ -43,14 +38,9 @@ public class CompactWidget extends BaseWidget {
         PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, launcherIntent, 0);
         views.setOnClickPendingIntent(R.id.widget_compact_container, pendingIntent);
 
-        views.setOnClickPendingIntent(R.id.widget_next,
-                MediaStyleHelper.getActionIntent(context, KEYCODE_MEDIA_NEXT));
-
-        views.setOnClickPendingIntent(R.id.widget_play_pause,
-                MediaStyleHelper.getActionIntent(context, KEYCODE_MEDIA_PLAY_PAUSE));
-
-        views.setOnClickPendingIntent(R.id.widget_previous,
-                MediaStyleHelper.getActionIntent(context, KEYCODE_MEDIA_PREVIOUS));
+        views.setOnClickPendingIntent(R.id.widget_next, getSkipNextIntent(context));
+        views.setOnClickPendingIntent(R.id.widget_play_pause, getPlayPauseIntent(context));
+        views.setOnClickPendingIntent(R.id.widget_previous, getSkipPreviousIntent(context));
 
         @ColorInt int buttonColor = ContextCompat.getColor(context, R.color.widget_button);
 

--- a/app/src/main/java/com/marverenic/music/widget/SquareWidget.java
+++ b/app/src/main/java/com/marverenic/music/widget/SquareWidget.java
@@ -11,14 +11,9 @@ import com.marverenic.music.R;
 import com.marverenic.music.model.Song;
 import com.marverenic.music.player.PlayerController;
 import com.marverenic.music.ui.library.LibraryActivity;
-import com.marverenic.music.utils.MediaStyleHelper;
 
 import rx.Observable;
 import timber.log.Timber;
-
-import static android.view.KeyEvent.KEYCODE_MEDIA_NEXT;
-import static android.view.KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE;
-import static android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS;
 
 public class SquareWidget extends BaseWidget {
 
@@ -44,14 +39,9 @@ public class SquareWidget extends BaseWidget {
         PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, launcherIntent, 0);
         views.setOnClickPendingIntent(R.id.widget_square_container, pendingIntent);
 
-        views.setOnClickPendingIntent(R.id.widget_next,
-                MediaStyleHelper.getActionIntent(context, KEYCODE_MEDIA_NEXT));
-
-        views.setOnClickPendingIntent(R.id.widget_play_pause,
-                MediaStyleHelper.getActionIntent(context, KEYCODE_MEDIA_PLAY_PAUSE));
-
-        views.setOnClickPendingIntent(R.id.widget_previous,
-                MediaStyleHelper.getActionIntent(context, KEYCODE_MEDIA_PREVIOUS));
+        views.setOnClickPendingIntent(R.id.widget_next, getSkipNextIntent(context));
+        views.setOnClickPendingIntent(R.id.widget_play_pause, getPlayPauseIntent(context));
+        views.setOnClickPendingIntent(R.id.widget_previous, getSkipPreviousIntent(context));
 
         return views;
     }

--- a/app/src/main/java/com/marverenic/music/widget/WideWidget.java
+++ b/app/src/main/java/com/marverenic/music/widget/WideWidget.java
@@ -13,14 +13,9 @@ import com.marverenic.music.R;
 import com.marverenic.music.model.Song;
 import com.marverenic.music.player.PlayerController;
 import com.marverenic.music.ui.library.LibraryActivity;
-import com.marverenic.music.utils.MediaStyleHelper;
 
 import rx.Observable;
 import timber.log.Timber;
-
-import static android.view.KeyEvent.KEYCODE_MEDIA_NEXT;
-import static android.view.KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE;
-import static android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS;
 
 public class WideWidget extends BaseWidget {
 
@@ -46,14 +41,9 @@ public class WideWidget extends BaseWidget {
         PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, launcherIntent, 0);
         views.setOnClickPendingIntent(R.id.widget_wide_container, pendingIntent);
 
-        views.setOnClickPendingIntent(R.id.widget_next,
-                MediaStyleHelper.getActionIntent(context, KEYCODE_MEDIA_NEXT));
-
-        views.setOnClickPendingIntent(R.id.widget_play_pause,
-                MediaStyleHelper.getActionIntent(context, KEYCODE_MEDIA_PLAY_PAUSE));
-
-        views.setOnClickPendingIntent(R.id.widget_previous,
-                MediaStyleHelper.getActionIntent(context, KEYCODE_MEDIA_PREVIOUS));
+        views.setOnClickPendingIntent(R.id.widget_next, getSkipNextIntent(context));
+        views.setOnClickPendingIntent(R.id.widget_play_pause, getPlayPauseIntent(context));
+        views.setOnClickPendingIntent(R.id.widget_previous, getSkipPreviousIntent(context));
 
         @ColorInt int buttonColor = ContextCompat.getColor(context, R.color.widget_button);
 


### PR DESCRIPTION
Resolves two issues on pre-L devices that affected how users interacted with widgets and the player notification. The first issue prevented the play and skip buttons from working. The second issue prevented pre-L devices from dismissing the player notification.

**Reproduction Steps:**
 - Create any one of Jockey's widgets on a pre-L device
 - Start Jockey with music queued
 - Press either the play, pause, skip, or previous buttons in the widget
 - Press any of the buttons in the notification
 - Observe that playback is not affected at all
 - Press the close button on the notification
 - Observe that the notification is not removed and that the service does not stop