### PR TITLE
Fix service not running in background after clean install

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -166,20 +166,9 @@ public class ServicePlayerController implements PlayerController {
 
         Intent serviceIntent = PlayerService.newIntent(mContext, true);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            int bindFlags = Context.BIND_WAIVE_PRIORITY | Context.BIND_AUTO_CREATE;
-            mContext.bindService(serviceIntent, mConnection, bindFlags);
-        } else {
-            /*
-                On Pre-Lollipop devices, directly calling bindService will couple the life of
-                the service to the lifetime of the binding. So if the binding is released, the
-                service will immediately be killed. To compensate, start the service manually and
-                THEN bind to it.
-             */
-            int bindFlags = Context.BIND_WAIVE_PRIORITY;
-            mContext.startService(serviceIntent);
-            mContext.bindService(serviceIntent, mConnection, bindFlags);
-        }
+        int bindFlags = Context.BIND_WAIVE_PRIORITY | Context.BIND_AUTO_CREATE;
+        mContext.bindService(serviceIntent, mConnection, bindFlags);
+        mContext.startService(serviceIntent);
     }
 
     private void unbindService() {


### PR DESCRIPTION
Fixes an issue where starting Jockey with an empty queue (either after clearing the queue manually or a clean install) would cause the service to be killed once the application leaves the foreground state.

Resolves [#162159686](https://www.pivotaltracker.com/story/show/162159686)

## Bug Details
**Reproduction Steps:**
Perform a fresh install of Jockey or clear the player queue and fully close Jockey
Open Jockey
Observe that the now playing toolbar is hidden and that the media playback notification is not visible
Play any song
Lock the screen, press the home button, or open any other application
Observe that the media notification has been removed and that music playback has stopped

**Expected behavior:**
Media playback should continue and the notification should not disappear when starting music for the first time in an app session