### PR TITLE
Match task icon with app theme on O+ devices

### DIFF
--- a/app/src/main/java/com/marverenic/music/data/store/PresetThemeStore.java
+++ b/app/src/main/java/com/marverenic/music/data/store/PresetThemeStore.java
@@ -10,7 +10,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.drawable.AdaptiveIconDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -29,6 +28,7 @@ import com.marverenic.music.data.annotations.AccentTheme;
 import com.marverenic.music.data.annotations.PrimaryTheme;
 import com.marverenic.music.player.PlayerService;
 import com.marverenic.music.ui.library.LibraryActivity;
+import com.marverenic.music.utils.Util;
 
 import static android.util.DisplayMetrics.DENSITY_HIGH;
 import static android.util.DisplayMetrics.DENSITY_LOW;
@@ -205,7 +205,7 @@ public class PresetThemeStore implements ThemeStore {
     }
 
     private Bitmap getAppIcon() {
-        return BitmapFactory.decodeResource(mContext.getResources(), getIconId());
+        return Util.drawableToBitmap(mContext.getResources().getDrawable(getIconId()));
     }
 
     @Override

--- a/app/src/main/java/com/marverenic/music/utils/Util.java
+++ b/app/src/main/java/com/marverenic/music/utils/Util.java
@@ -8,6 +8,9 @@ import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
 import android.media.MediaMetadataRetriever;
 import android.media.audiofx.AudioEffect;
 import android.net.ConnectivityManager;
@@ -282,6 +285,24 @@ public final class Util {
 
     private static boolean isMimeTypeAudio(String mime) {
         return mime != null && mime.startsWith("audio") || AUDIO_MIMES.contains(mime);
+    }
+
+    public static Bitmap drawableToBitmap(Drawable drawable) {
+        if (drawable instanceof BitmapDrawable) {
+            BitmapDrawable bitmapDrawable = (BitmapDrawable) drawable;
+            if (bitmapDrawable.getBitmap() != null) {
+                return bitmapDrawable.getBitmap();
+            }
+        }
+
+        int width = Math.max(drawable.getIntrinsicWidth(), 1);
+        int height = Math.max(drawable.getIntrinsicHeight(), 1);
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        drawable.draw(canvas);
+        return bitmap;
     }
 
 }


### PR DESCRIPTION
Completes [#155288425](https://www.pivotaltracker.com/story/show/155288425).

On pre-O devices, the icon shown on the overview page would automatically be updated to match the app theme. This was broken on Oreo devices with the introduction of adaptive icons. This PR matches this behavior on newer devices.

### Screenshot
Before | After
|:-:|:-:|
![device-2018-12-30-161106](https://user-images.githubusercontent.com/10948413/50551403-bd552600-0c4d-11e9-923f-f13506e323da.png) | ![device-2018-12-30-161023](https://user-images.githubusercontent.com/10948413/50551406-c34b0700-0c4d-11e9-820b-69d240489ebc.png)
