### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report an error or crash in Jockey
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. The action should complete successfully
+
+**Actual behavior**
+Describe where the application deviates from the expected behavior:
+1. Go to '...'
+2. Click on '....'
+3. Observe that an error message appears
+
+**Screenshots**
+If applicable, add screenshots to help explain the problem.
+
+**Device information:**
+ - Device Model: [e.g. Google Pixel 3, Samsung Galaxy S8, etc.]
+ - Android version: [e.g. Android 5.1]
+ - Device Modifications: [e.g. none, rooted, flashed custom ROM]
+
+**Additional context**
+Add any other context about how you use Jockey that could be relevant to the issue. For example, if the app shows an error when trying to play a specific song, then you should include information like what format the song is, and if its name includes letters that aren't in the English alphabet.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea to improve Jockey
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+Describe what the problem is in a paragraph or two. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+If applicable, add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+Replace this paragraph with a summary of the functionality or work introduced as part of this PR. If applicable, include a link to an applicable story in Pivotal Tracker or issue on GitHub.
+
+### Testing Steps
+Replace this paragraph with a set of instructions stating how the work here can be tested or reviewed. For bug fixes, include the expected and actual behavior that this PR addresses.
+
+### Screenshots
+_Omit this section if no visual changes are introduced as part of this PR._
+
+| Before | After |
+|:------:|:-----:|
+![before]() | ![after]()


### PR DESCRIPTION
This adds a set of issue templates and PR templates to improve consistency. GitHub will pre-populate these templates for new PR's and issues.