### PR TITLE
Fix launch crash in release builds on pre-L devices

### DIFF
--- a/app/src/main/java/com/marverenic/music/utils/OkHttpUtils.java
+++ b/app/src/main/java/com/marverenic/music/utils/OkHttpUtils.java
@@ -1,6 +1,7 @@
 package com.marverenic.music.utils;
 
 import android.os.Build;
+import android.support.annotation.Keep;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -57,6 +58,7 @@ public class OkHttpUtils {
     private static class Tls12SocketFactory extends SSLSocketFactory {
         private static final String[] TLS_V12_ONLY = {"TLSv1.2"};
 
+        @Keep
         final SSLSocketFactory delegate;
 
         public Tls12SocketFactory(SSLSocketFactory base) {


### PR DESCRIPTION
Completes [#164159454](https://www.pivotaltracker.com/story/show/164159454).

Fixes a crash where builds that use Proguard would fail to start on older devices that require an SSL workaround to check for privacy policy changes.

### Testing Steps
Run a release build of the app on a device running Android 4.1-4.4.
