### PR TITLE
Fix various issues related to music player service

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -1200,11 +1200,8 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
         startSleepTimer(0);
 
         mFocused = false;
-        mCallback = null;
         mMediaPlayer.release();
         mMediaSession.release();
-        mMediaPlayer = null;
-        mContext = null;
     }
 
     public boolean isReleased() {

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.IBinder;
 import android.support.annotation.DrawableRes;
+import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.media.app.NotificationCompat.MediaStyle;
@@ -56,7 +57,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     /**
      * The media player for the service instance
      */
-    @Internal MusicPlayer musicPlayer;
+    @Internal @Nullable MusicPlayer musicPlayer;
 
     @Inject PlaybackPersistenceManager mPlaybackPersistenceManager;
 
@@ -169,7 +170,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     }
 
     private void notifyNowPlaying() {
-        if (musicPlayer.getNowPlaying() == null) {
+        if (musicPlayer == null || musicPlayer.getNowPlaying() == null) {
             Timber.i("Not showing notification -- nothing is playing");
             return;
         }
@@ -184,14 +185,20 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     private void notifyNowPlaying(boolean foreground) {
         Timber.i("notifyNowPlaying called");
 
-        MediaSessionCompat mediaSession = musicPlayer.getMediaSession();
-        if (mediaSession == null) {
+        if (musicPlayer == null || musicPlayer.getMediaSession() == null) {
             Timber.i("Not showing notification. Media session is uninitialized");
             return;
         }
 
-        NotificationCompat.Builder builder =
-                MediaStyleHelper.from(this, mediaSession, NOTIFICATION_CHANNEL_ID);
+        if (mBeQuiet) {
+            mBeQuiet = !musicPlayer.isPlaying();
+        }
+
+        NotificationCompat.Builder builder = MediaStyleHelper.from(
+                this,
+                musicPlayer.getMediaSession(),
+                NOTIFICATION_CHANNEL_ID
+        );
 
         setupNotificationActions(builder);
 
@@ -212,7 +219,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
 
     @DrawableRes
     private int getNotificationIcon() {
-        if (musicPlayer.isPlaying()) {
+        if (musicPlayer != null && musicPlayer.isPlaying()) {
             return R.drawable.ic_play_arrow_24dp;
         } else {
             return R.drawable.ic_pause_24dp;
@@ -223,7 +230,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         addNotificationAction(builder, R.drawable.ic_skip_previous_36dp,
                 R.string.action_previous, PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS);
 
-        if (musicPlayer.isPlaying()) {
+        if (musicPlayer != null && musicPlayer.isPlaying()) {
             addNotificationAction(builder, R.drawable.ic_pause_36dp,
                     R.string.action_pause, PlaybackStateCompat.ACTION_PLAY_PAUSE);
         } else {
@@ -249,7 +256,6 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         }
 
         mStopped = false;
-        mBeQuiet &= !musicPlayer.isPlaying();
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             startForeground(NOTIFICATION_ID, notification);
@@ -316,7 +322,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         mStopped = true;
 
         // If the UI process is still running, don't kill the process, only remove its notification
-        if (isUiProcessRunning()) {
+        if (isUiProcessRunning() && musicPlayer != null) {
             musicPlayer.pause();
             stopForeground(true);
             return;

--- a/app/src/main/java/com/marverenic/music/player/PlayerService.java
+++ b/app/src/main/java/com/marverenic/music/player/PlayerService.java
@@ -72,7 +72,7 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
     /**
      * When set to true, notifications will not be displayed until the service enters the foreground
      */
-    private boolean mBeQuiet;
+    private boolean mBeQuiet = true;
 
     public static Intent newIntent(Context context, boolean silent) {
         Intent intent = new Intent(context, PlayerService.class);
@@ -119,7 +119,9 @@ public class PlayerService extends Service implements MusicPlayer.OnPlaybackChan
         super.onStartCommand(intent, flags, startId);
 
         if (intent != null && MediaStoreUtil.hasPermission(this)) {
-            mBeQuiet = intent.getBooleanExtra(EXTRA_START_SILENT, false);
+            if (mBeQuiet) {
+                mBeQuiet = intent.getBooleanExtra(EXTRA_START_SILENT, true);
+            }
 
             if (intent.hasExtra(Intent.EXTRA_KEY_EVENT)) {
                 MediaButtonReceiver.handleIntent(musicPlayer.getMediaSession(), intent);

--- a/app/src/main/java/com/marverenic/music/player/extensions/scrobbler/SlsMessenger.java
+++ b/app/src/main/java/com/marverenic/music/player/extensions/scrobbler/SlsMessenger.java
@@ -3,6 +3,7 @@ package com.marverenic.music.player.extensions.scrobbler;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.support.annotation.Nullable;
 
 import com.marverenic.music.R;
 import com.marverenic.music.model.Song;
@@ -66,31 +67,39 @@ public class SlsMessenger {
      * Should be called when new song began to play
      * @param song the new song
      */
-    public void sendStart(Song song) {
-        mContext.sendBroadcast(withSong(song).putExtra(KEY_STATE, STATE_START));
+    public void sendStart(@Nullable Song song) {
+        if (song != null) {
+            mContext.sendBroadcast(withSong(song).putExtra(KEY_STATE, STATE_START));
+        }
     }
 
     /**
      * Should be called when a song was resumed after pause
      * @param song the resumed song
      */
-    public void sendResume(Song song) {
-        mContext.sendBroadcast(withSong(song).putExtra(KEY_STATE, STATE_RESUME));
+    public void sendResume(@Nullable Song song) {
+        if (song != null) {
+            mContext.sendBroadcast(withSong(song).putExtra(KEY_STATE, STATE_RESUME));
+        }
     }
 
     /**
      * Should be called when song is paused
      * @param song the paused song
      */
-    public void sendPause(Song song) {
-        mContext.sendBroadcast(withSong(song).putExtra(KEY_STATE, STATE_PAUSE));
+    public void sendPause(@Nullable Song song) {
+        if (song != null) {
+            mContext.sendBroadcast(withSong(song).putExtra(KEY_STATE, STATE_PAUSE));
+        }
     }
 
     /**
      * Should be called when a song is just completed
      * @param song the completed song
      */
-    public void sendComplete(Song song) {
-        mContext.sendBroadcast(withSong(song).putExtra(KEY_STATE, STATE_COMPLETE));
+    public void sendComplete(@Nullable Song song) {
+        if (song != null) {
+            mContext.sendBroadcast(withSong(song).putExtra(KEY_STATE, STATE_COMPLETE));
+        }
     }
 }

--- a/app/src/main/java/com/marverenic/music/ui/nowplaying/MiniplayerViewModel.java
+++ b/app/src/main/java/com/marverenic/music/ui/nowplaying/MiniplayerViewModel.java
@@ -2,8 +2,6 @@ package com.marverenic.music.ui.nowplaying;
 
 import android.content.Context;
 import android.databinding.Bindable;
-import android.databinding.ObservableField;
-import android.databinding.ObservableInt;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.Nullable;
@@ -15,6 +13,8 @@ import com.marverenic.music.model.Song;
 import com.marverenic.music.player.PlayerController;
 import com.marverenic.music.ui.BaseViewModel;
 
+import timber.log.Timber;
+
 public class MiniplayerViewModel extends BaseViewModel {
 
     private PlayerController mPlayerController;
@@ -23,17 +23,13 @@ public class MiniplayerViewModel extends BaseViewModel {
     private Song mSong;
     private boolean mPlaying;
 
-    private final ObservableField<Bitmap> mArtwork;
-    private final ObservableInt mDuration;
-    private final ObservableInt mProgress;
+    private Bitmap mArtwork;
+    private int mDuration;
+    private int mProgress;
 
     public MiniplayerViewModel(Context context, PlayerController playerController) {
         super(context);
         mPlayerController = playerController;
-
-        mArtwork = new ObservableField<>();
-        mProgress = new ObservableInt();
-        mDuration = new ObservableInt();
 
         setSong(null);
     }
@@ -50,15 +46,20 @@ public class MiniplayerViewModel extends BaseViewModel {
     }
 
     public void setCurrentPosition(int position) {
-        mProgress.set(position);
+        mProgress = position;
+        notifyPropertyChanged(BR.songDuration);
+        notifyPropertyChanged(BR.progress);
     }
 
     public void setDuration(int duration) {
-        mDuration.set(duration);
+        mDuration = duration;
+        notifyPropertyChanged(BR.songDuration);
+        notifyPropertyChanged(BR.progress);
     }
 
     public void setArtwork(Bitmap artwork) {
-        mArtwork.set(artwork);
+        mArtwork = artwork;
+        notifyPropertyChanged(BR.artwork);
     }
 
     @Bindable
@@ -79,15 +80,18 @@ public class MiniplayerViewModel extends BaseViewModel {
         }
     }
 
-    public ObservableInt getSongDuration() {
+    @Bindable
+    public int getSongDuration() {
         return mDuration;
     }
 
-    public ObservableField<Bitmap> getArtwork() {
+    @Bindable
+    public Bitmap getArtwork() {
         return mArtwork;
     }
 
-    public ObservableInt getProgress() {
+    @Bindable
+    public int getProgress() {
         return mProgress;
     }
 


### PR DESCRIPTION
This fixes [#162533648](https://www.pivotaltracker.com/story/show/162533648) as well as a few other miscellaneous issues related to communication between the player service and UI procress.

### Testing Steps
In order of commit, the following changes have been made.

#### Reduction in the number of unexpected notifications from the service
There was a logic issue that would cause the playback notification to appear when Jockey was not in the foreground or had not yet begun to play music in this app session. This should reduce the frequency of unexpected playback notifications.

#### The playback notification gets stuck in the foreground state
On devices running Android Oreo and higher, there are changes to background execution limits that may cause the playback notification to get stuck in the playing state, leaving an playback notification that could not be dismissed.

To reproduce, play music without opening the app. You can do this by using a pair of headphones with an inline remote or with a bluetooth stereo that has media controls. Then, pause music. Music will stop playing, but the notification will not be updated and cannot be dismissed. Tapping the pause button will actually play music. Tapping the pause button in the notification will not cause this behavior and could be used to dismiss the notification.

#### The playback service may crash silently
There were a few fatal exceptions that were causing the player service to crash, but a user-facing alert was not shown because the app was not in the foreground. To reproduce, enable "Always Show Crash Dialog" in the developer settings (under "Apps" at the bottom of the list). This PR fixes crash dialogs that would appear after dismissing the playback notification.

#### Jockey would not correctly show the seek progress on app launch
This is actually a UI error, but it's a small change that I'm lumping it with these other issues. When launching Jockey from a cold start, it will now display the correct seek progress for the current song in the now playing toolbar at the bottom of the screen based on wherever playback was left off in the previous session. Previously, this seek bar would always indicate the song was starting from the beginning until the playback state changed.