### PR TITLE
Fix major UI-crashes from Crashlytics

### DIFF
--- a/app/src/main/java/com/marverenic/music/ui/search/SearchFragment.java
+++ b/app/src/main/java/com/marverenic/music/ui/search/SearchFragment.java
@@ -38,6 +38,8 @@ public class SearchFragment extends BaseToolbarFragment {
     private FragmentSearchBinding mBinding;
     private SearchViewModel mViewModel;
 
+    private String initialQuery = "";
+
     public static SearchFragment newInstance() {
         return new SearchFragment();
     }
@@ -48,30 +50,29 @@ public class SearchFragment extends BaseToolbarFragment {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         JockeyApplication.getComponent(this).inject(this);
+
+        if (savedInstanceState != null) {
+            initialQuery = savedInstanceState.getString(KEY_SAVED_QUERY, initialQuery);
+        }
     }
 
     @Override
     protected View onCreateContentView(LayoutInflater inflater, @Nullable ViewGroup container,
                                        @Nullable Bundle savedInstanceState) {
-
         mBinding = FragmentSearchBinding.inflate(inflater, container, false);
         mViewModel = new SearchViewModel(getContext(), getFragmentManager(), mPlayerController,
                 mMusicStore, mPlaylistStore,
-                OnSongSelectedListener.defaultImplementation(getActivity(), mPreferenceStore));
+                OnSongSelectedListener.defaultImplementation(getActivity(), mPreferenceStore),
+                initialQuery);
 
         mPlayerController.getNowPlaying()
                 .compose(bindToLifecycle())
                 .subscribe(mViewModel::setCurrentSong, throwable -> {
                     Timber.e(throwable, "Failed to update current song");
                 });
-
-        if (savedInstanceState != null) {
-            String lastQuery = savedInstanceState.getString(KEY_SAVED_QUERY, "");
-            mViewModel.setSearchQuery(lastQuery);
-        }
 
         mBinding.setViewModel(mViewModel);
         setHasOptionsMenu(true);
@@ -117,6 +118,10 @@ public class SearchFragment extends BaseToolbarFragment {
     }
 
     public void setSearchQuery(String query) {
-        mViewModel.setSearchQuery(query);
+        if (mViewModel != null) {
+            mViewModel.setSearchQuery(query);
+        } else {
+            initialQuery = query;
+        }
     }
 }

--- a/app/src/main/java/com/marverenic/music/ui/search/SearchViewModel.java
+++ b/app/src/main/java/com/marverenic/music/ui/search/SearchViewModel.java
@@ -60,7 +60,8 @@ public class SearchViewModel extends BaseViewModel {
     public SearchViewModel(Context context, FragmentManager fragmentManager,
                            PlayerController playerController, MusicStore musicStore,
                            PlaylistStore playlistStore,
-                           @Nullable OnSongSelectedListener songSelectedListener) {
+                           @Nullable OnSongSelectedListener songSelectedListener,
+                           String initialQuery) {
 
         super(context);
         mFragmentManager = fragmentManager;
@@ -68,7 +69,7 @@ public class SearchViewModel extends BaseViewModel {
         mMusicStore = musicStore;
         mPlaylistStore = playlistStore;
 
-        mQuerySubject = BehaviorSubject.create("");
+        mQuerySubject = BehaviorSubject.create(initialQuery);
 
         createAdapter(songSelectedListener);
         observeSearchQuery();

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     //noinspection GroovyAssignabilityCheck
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Fixes [#164840198](https://www.pivotaltracker.com/story/show/164840198) and [#164840086](https://www.pivotaltracker.com/story/show/164840086).

This PR fixes two UI-related crashes reported in Crashlytics. Stacktraces can be found in the Pivotal Tracker links above.

### Testing Steps
#### Crash when reading shuffle state
I don't have solid reproduction steps here, but it appears that calling `mShuffleMode.lastValue()` in `ServicePlayerController` isn't a reliable way to determine whether shuffle is enabled or not. There is now a fallback value that will be used.

#### Crash on SearchActivity
This can be reproduced by attempting to play music from a search query intent. An easy way to do this is to ask the Google Assistant to play music in your library -- you'll immediately see an NPE. This was happening because the hosting activity was attempting to interact with `SearchFragment` before its `onCreate` lifecycle event was called.