### PR TITLE
Add translations for repeat mode names

### DIFF
--- a/app/src/main/res/menu/activity_now_playing_repeat.xml
+++ b/app/src/main/res/menu/activity_now_playing_repeat.xml
@@ -2,15 +2,15 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:id="@+id/menu_item_repeat_none"
-        android:title="Repeat none"/>
+        android:title="@string/action_repeat_none"/>
 
     <item android:id="@+id/menu_item_repeat_all"
-        android:title="Repeat all"/>
+        android:title="@string/action_repeat_all"/>
 
     <item android:id="@+id/menu_item_repeat_one"
-        android:title="Repeat one"/>
+        android:title="@string/action_repeat_one"/>
 
     <item android:id="@+id/menu_item_repeat_multi"
-        android:title="Multi-Repeat..."/>
+        android:title="@string/action_repeat_multi"/>
 
 </menu>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -99,13 +99,17 @@
     <string name="action_discard_changes">Descartar los cambios</string>
     <string name="action_edit_playlist_rules">Editar filtros</string>
     <string name="action_shuffle_all">Baraja todos</string>
+    <string name="action_repeat_none">Repetir ninguna</string>
+    <string name="action_repeat_one">Repetir uno</string>
+    <string name="action_repeat_all">Repetir todos</string>
+    <string name="action_repeat_multi">Múlti-Repetir&#8230;</string>
 
     <!-- Confirmation messages -->
     <string name="confirm_disable_shuffle">Aleatorio desactivado</string>
     <string name="confirm_enable_shuffle">Aleatorio activado</string>
     <string name="confirm_disable_repeat">Repetir desactivado</string>
     <string name="confirm_enable_repeat">Repetir activado</string>
-    <string name="confirm_enable_multi_repeat">Repetición múltiple (%d) activada</string>
+    <string name="confirm_enable_multi_repeat">Múlti-Repetir (%d) activada</string>
     <string name="confirm_enable_repeat_one">Repetir uno activado</string>
     <string name="confirm_disable_sleep_timer">Desactivado el Temporizador de Apagado</string>
     <string name="confirm_refresh_library">Biblioteca actualizada</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -83,6 +83,10 @@
     <string name="action_discard_changes">Wijzigingen ongedaan maken</string>
     <string name="action_edit_playlist_rules">Bewerk filters</string>
     <string name="action_shuffle_all">Shuffle alles</string>
+    <string name="action_repeat_none">Niets herhalen</string>
+    <string name="action_repeat_one">Één lied herhalen</string>
+    <string name="action_repeat_all">Alles herhalen</string>
+    <string name="action_repeat_multi">Multi-herhalen&#8230;</string>
 
     <!-- Confirmation messages -->
     <string name="confirm_disable_shuffle">Shuffle uitgeschakeld</string>
@@ -90,7 +94,7 @@
     <string name="confirm_disable_repeat">Herhalen uitgeschakeld</string>
     <string name="confirm_enable_repeat">Herhalen ingeschakeld</string>
     <string name="confirm_enable_multi_repeat">Multi-herhalen (%d) ingeschakeld</string>
-    <string name="confirm_enable_repeat_one">Één keer herhalen ingeschakeld</string>
+    <string name="confirm_enable_repeat_one">Één lied herhalen ingeschakeld</string>
     <string name="confirm_disable_sleep_timer">Slaaptimer uitgeschakeld</string>
     <string name="confirm_refresh_library">Bibliotheek herladen gelukt</string>
     <string name="confirm_clear_queue">Wachtrij gewist</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Activity titles -->
     <string name="header_playlists">Afspeellijsten</string>
     <string name="header_songs">Nummers</string>
     <string name="header_artists">Artiesten</string>
@@ -14,15 +16,23 @@
     <string name="header_browser">Navigeren</string>
     <string name="header_recently_added">Recent Toegevoegd</string>
     <string name="header_all_songs">Alle Nummers</string>
+
+    <!-- Data types -->
     <string name="playlist">Afspeellijst</string>
     <string name="header_create_playlist">Creëer afspeellijst</string>
+
+    <!-- Other headers -->
     <string name="playlist_auto">Slimme Afspeellijst</string>
     <string name="header_add_queue_to_playlist">Voeg wachtrij toe aan afspeellijst</string>
     <string name="playlist_auto_new">Nieuwe Slimme Afspeellijst</string>
     <string name="playlist_auto_choose_by">Kies nummers met</string>
+
+    <!-- First start Strings -->
     <string name="first_launch_title">Welkom bij Jockey</string>
     <string name="action_read_privacy_policy">Open</string>
     <string name="alert_privacy_policy_updated">Jockey\'s privacybeleid is gewijzigd</string>
+
+    <!-- Menu actions -->
     <string name="action_refresh">Bibliotheek herladen</string>
     <string name="action_sort">Sorteer&#8230;</string>
     <string name="action_sort_random">Willekeurige volgorde</string>
@@ -43,6 +53,8 @@
     <string name="action_add_queue_to_playlist">Wachtrij toevoegen aan afspeellijst&#8230;</string>
     <string name="action_navigate_up">Omhoog gaan</string>
     <string name="action_remove">Verwijderen</string>
+
+    <!-- Item menu actions -->
     <string name="action_queue_next">Speel hierna af</string>
     <string name="action_queue_last">Speel als laatste af</string>
     <string name="action_navigate_to_artist">Ga naar artiest</string>
@@ -51,6 +63,8 @@
     <string name="action_add_to_playlist">Voeg toe aan afspeellijst&#8230;</string>
     <string name="action_delete">Verwijder</string>
     <string name="action_edit_smart_playlist">Bewerken&#8230;</string>
+
+    <!-- Other Actions -->
     <string name="action_skip">Overslaan</string>
     <string name="action_play">Afspelen</string>
     <string name="action_pause">Pauzeer</string>
@@ -69,6 +83,8 @@
     <string name="action_discard_changes">Wijzigingen ongedaan maken</string>
     <string name="action_edit_playlist_rules">Bewerk filters</string>
     <string name="action_shuffle_all">Shuffle alles</string>
+
+    <!-- Confirmation messages -->
     <string name="confirm_disable_shuffle">Shuffle uitgeschakeld</string>
     <string name="confirm_enable_shuffle">Shuffle ingeschakeld</string>
     <string name="confirm_disable_repeat">Herhalen uitgeschakeld</string>
@@ -88,14 +104,20 @@
     <string name="widget_wide_name">Jockey Wijd</string>
     <string name="widget_square_name">Jockey Illustratie</string>
     <string name="confirm_removed_rule">Regel verwijderd</string>
+
+    <!-- Dialog messages -->
     <string name="prompt_save_changes">Wijzigingen opslaan?</string>
     <string name="prompt_discard_changes">Wijzigingen ongedaan maken?</string>
     <string name="confirm_application_exit">Druk nog een keer om af te sluiten</string>
+
+    <!-- Error messages -->
     <string name="message_play_error_not_found">Jockey kon &#8220;%1$s&#8221; niet vinden</string>
     <string name="message_play_error_io_exception">&#8220;%1$s&#8221; kon niet afgespeeld worden</string>
     <string name="error_hint_duplicate_playlist">Voer een unieke naam in voor de afspeellijst</string>
     <string name="error_hint_empty_playlist">Voer een naam in voor de afspeellijst</string>
     <string name="error_playback_from_files_failed">Jockey kon %s niet afspelen</string>
+
+    <!-- Formatted Messages -->
     <string name="message_added_song">&#8220;%1$s&#8221; is toegevoegd aan &#8220;%2$s&#8221;</string>
     <string name="message_created_playlist">Afspeellijst aangemaakt: &#8220;%1$s&#8221;</string>
     <string name="message_removed_playlist">Afspeellijst verwijderd: &#8220;%1$s&#8221;</string>
@@ -117,6 +139,8 @@
     <string name="confirm_dir_already_excluded">&#8220;%1$s&#8221; wordt al uitgesloten</string>
     <string name="confirm_dir_already_included">&#8220;%1$s&#8221; wordt al ingesloten</string>
     <string name="message_removed_directory">Map &#8220;%1$s&#8221; is verwijderd</string>
+
+    <!-- Empty state & unknown strings -->
     <string name="nothing_playing">Er wordt niets afgespeeld</string>
     <string name="unknown_artist">Onbekende Artiest</string>
     <string name="unknown_album">Onbekend Album</string>
@@ -194,10 +218,14 @@
     <string name="hint_playlist_name">Afspeellijst naam</string>
     <string name="time_in_min_format">%1$d min</string>
     <string name="multi_repeat_description">Multi-herhalen herhaalt het nummer voor een bepaald aantal keren. Als het volgende nummer start zal Multi-herhalen uitgeschakeld worden.</string>
+
+    <!-- Equalizer Strings -->
     <string name="equalizer_unsupported">Jouw apparaat ondersteunt geen equalizers</string>
     <string name="equalizer_preset_prefix">Sjabloon:</string>
     <string name="equalizer_more_options_detail">Klik en houd ingedrukt voor meer opties</string>
     <string name="header_equalizer">Equalizer</string>
+
+    <!-- Preference Strings -->
     <string name="pref_equalizer">Equalizer</string>
     <string name="pref_directory_include">Mappen insluiten</string>
     <string name="pref_directory_exclude">Mappen uitsluiten</string>
@@ -239,6 +267,8 @@
     <string name="uses_fastscroll_detail">Versie 1.0.16; gedistributeerd door Tim Malseed onder een Apache License, versie 2.0</string>
     <string name="uses_seek_arc_detail">Versie 1.1; gedistributeerd door Triggertrap Ltd (Neil Davies) onder een MIT License</string>
     <string name="uses_timber_detail">Versie 1.1; gedistributeerd door Triggertrap Ltd (Neil Davies) onder een MIT License</string>
+
+    <!-- About Activity Strings -->
     <string name="about_description">Jockey is een muziekspeler voor Android 4.1 en hoger, gefocused op simpliciteit, snelheid en design gedistributeerd onder een Apache 2.0 licentie.</string>
     <string name="empty_included_dirs_detail">Jockey kan beperkt worden om in alleen specifieke mappen te doorzoeken, druk op de &#8220;+&#8221; knop om een map in te sluiten.</string>
     <string name="empty_excluded_dirs_detail">Jockey kan beperkt worden om sommige mappen over te slaan, druk op de &#8220;+&#8221; knop om een map uit te sluiten.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -84,7 +84,7 @@
     <string name="action_edit_playlist_rules">Bewerk filters</string>
     <string name="action_shuffle_all">Shuffle alles</string>
     <string name="action_repeat_none">Niets herhalen</string>
-    <string name="action_repeat_one">Één lied herhalen</string>
+    <string name="action_repeat_one">Oneindig herhalen</string>
     <string name="action_repeat_all">Alles herhalen</string>
     <string name="action_repeat_multi">Multi-herhalen&#8230;</string>
 
@@ -94,7 +94,7 @@
     <string name="confirm_disable_repeat">Herhalen uitgeschakeld</string>
     <string name="confirm_enable_repeat">Herhalen ingeschakeld</string>
     <string name="confirm_enable_multi_repeat">Multi-herhalen (%d) ingeschakeld</string>
-    <string name="confirm_enable_repeat_one">Één lied herhalen ingeschakeld</string>
+    <string name="confirm_enable_repeat_one">Oneindig herhalen ingeschakeld</string>
     <string name="confirm_disable_sleep_timer">Slaaptimer uitgeschakeld</string>
     <string name="confirm_refresh_library">Bibliotheek herladen gelukt</string>
     <string name="confirm_clear_queue">Wachtrij gewist</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,10 @@
     <string name="action_edit_playlist_rules">Edit filters</string>
     <string name="action_open_in_last_fm" translatable="false">Last.fm</string>
     <string name="action_shuffle_all">Shuffle all</string>
+    <string name="action_repeat_none">Repeat none</string>
+    <string name="action_repeat_one">Repeat one</string>
+    <string name="action_repeat_all">Repeat all</string>
+    <string name="action_repeat_multi">Multi-Repeat&#8230;</string>
 
     <!-- Confirmation messages -->
     <string name="confirm_disable_shuffle">Disabled shuffle</string>


### PR DESCRIPTION
Completes [#164747532](https://www.pivotaltracker.com/story/show/164747532).

The repeat mode menu was previously using hardcoded strings in the menu resource. This PR introduces new string resources to localize that menu.

### Screenshots
| Before | After |
|:------:|:-----:|
![Screenshot_1557798766](https://user-images.githubusercontent.com/10948413/57665343-79920600-75c9-11e9-974b-1184cdd8bd74.png) | ![Screenshot_1557798306](https://user-images.githubusercontent.com/10948413/57665048-6d597900-75c8-11e9-9f56-94277ce105d5.png)
![Screenshot_1557798772](https://user-images.githubusercontent.com/10948413/57665351-7eef5080-75c9-11e9-80d0-4ed4fdc8895f.png) | ![Screenshot_1557798471](https://user-images.githubusercontent.com/10948413/57665146-c88b6b80-75c8-11e9-89d7-676cb362fe47.png)
![Screenshot_1557798685](https://user-images.githubusercontent.com/10948413/57665291-451e4a00-75c9-11e9-9151-b3927dc5b061.png) | ![Screenshot_1557798632](https://user-images.githubusercontent.com/10948413/57665249-29b33f00-75c9-11e9-8294-9970ace43489.png)

