### PR TITLE
Fix potential UnsupportedOperationException

### DIFF
--- a/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
+++ b/app/src/main/java/com/marverenic/music/player/ServicePlayerController.java
@@ -634,7 +634,8 @@ public class ServicePlayerController implements PlayerController {
 
     @Override
     public Observable<List<Song>> getQueue() {
-        return mQueue.getObservable();
+        return mQueue.getObservable()
+                .map(ArrayList::new);
     }
 
     @Override


### PR DESCRIPTION
Fixes [#165954849](https://www.pivotaltracker.com/story/show/165954849).

This PR fixes an issue where setting the queue as an unmodifiable list (like the list of all songs) might cause an UnsupportedOperationException to be thrown if another component got a reference to the list and attempted to modify it.

### Testing Steps
1. Open app as usual
2. Make sure shuffle is disabled
3. Choose any song from Songs tab
4. Open the queue and try to rearrange any of the songs in the list
5. The app will crash with `UnsupportedOperationException`