### PR TITLE
Fix potential IndexOutOfBoundsException

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     implementation "com.android.support:cardview-v7:$rootProject.supportLibVersion"
     implementation "com.android.support:preference-v14:$rootProject.supportLibVersion"
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    implementation 'com.google.android.exoplayer:exoplayer:2.6.1'
+    implementation "com.google.android.exoplayer:exoplayer-core:$rootProject.exoplayerVersion"
 
     implementation "android.arch.persistence.room:runtime:$rootProject.roomVersion"
     annotationProcessor "android.arch.persistence.room:compiler:$rootProject.roomVersion"

--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -453,10 +453,30 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
     private List<QueueItem> buildQueueWindow() {
         List<Song> queue = mMediaPlayer.getQueue();
         int queueIndex = mMediaPlayer.getQueueIndex();
+
+        int startIndex;
         int windowSize = Math.min(queue.size(), MEDIA_SESSION_QUEUE_MAX_SIZE);
 
-        int prefixLength = Math.min(queueIndex, MEDIA_SESSION_QUEUE_MAX_SIZE / 2 - 1);
-        int startIndex = queueIndex - prefixLength;
+        // Attempt to center the window around the current track
+        if (queue.size() <= MEDIA_SESSION_QUEUE_MAX_SIZE) {
+            // We can fit the whole queue in the window
+            startIndex = 0;
+        } else if (queueIndex >= queue.size() / 2) {
+            // Current song is beyond the halfway point in the queue.
+            // Take up to half of the window on the right half of the queue, and add any leftover
+            // capacity to the other half of the window.
+
+            int suffixLength = Math.min(queue.size() - queueIndex - 1, MEDIA_SESSION_QUEUE_MAX_SIZE / 2);
+            int prefixLength = MEDIA_SESSION_QUEUE_MAX_SIZE - suffixLength;
+            startIndex = queueIndex - prefixLength;
+        } else {
+            // Current song is before the halfway point in the queue.
+            // This is the opposite of the previous case -- we'll add any leftover capacity to the
+            // right half of the window.
+
+            int prefixLength = Math.min(queueIndex, MEDIA_SESSION_QUEUE_MAX_SIZE / 2);
+            startIndex = queueIndex - prefixLength;
+        }
 
         List<QueueItem> window = new ArrayList<>();
         for (int i = startIndex; i < startIndex + windowSize; i++) {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ allprojects {
 ext {
     targetSdkVersion = 27
     supportLibVersion = '27.1.0'
+    exoplayerVersion = '2.6.1'
     roomVersion = '1.1.0'
 }
 

--- a/exoplayer-flac/build.gradle
+++ b/exoplayer-flac/build.gradle
@@ -28,6 +28,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.exoplayer:exoplayer:2.6.1'
+    implementation "com.google.android.exoplayer:exoplayer-core:$rootProject.exoplayerVersion"
 }
 


### PR DESCRIPTION
Completes [#166105021](https://www.pivotaltracker.com/story/show/166105021).

The logic used to generate a sliding window of the current queue for the MediaSession breaks for long queues if the index of the current song is less than 120 songs away from the end of the queue. This PR revisits the logic used to generate this window, which should make it more robust.

### Testing Steps
1. Enqueue a large number of songs (~500 is a good number)
2. Start playing the second-to-last song in the queue
3. Press the skip button

**Expected behavior:** The last song in the queue begins to play
**Actual behavior:** The music player service crashes