### PR TITLE
Bump targetSdk to API level 28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/android:api-27-alpha
+      - image: circleci/android:api-28
 
     steps:
         - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Built application files
 *.apk
 *.ap_
+*.aab
 
 # Files for the Dalvik VM
 *.dex

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,6 +102,8 @@ dependencies {
 
     implementation "com.android.support:appcompat-v7:$rootProject.supportLibVersion"
     implementation "com.android.support:design:$rootProject.supportLibVersion"
+    implementation "com.android.support:support-media-compat:$rootProject.supportLibVersion"
+    implementation "com.android.support:support-annotations:$rootProject.supportLibVersion"
     implementation "com.android.support:palette-v7:$rootProject.supportLibVersion"
     implementation "com.android.support:recyclerview-v7:$rootProject.supportLibVersion"
     implementation "com.android.support:cardview-v7:$rootProject.supportLibVersion"
@@ -117,7 +119,11 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.7'
 
     implementation 'com.simplecityapps:recyclerview-fastscroll:1.0.16'
-    implementation 'com.h6ah4i.android.widget.verticalseekbar:verticalseekbar:0.5.2'
+    implementation ('com.h6ah4i.android.widget.verticalseekbar:verticalseekbar:0.5.2') {
+        exclude group: 'com.android.support'
+        exclude module: 'appcompat-v7'
+        exclude module: 'support-v4'
+    }
 
     implementation 'com.google.dagger:dagger:2.6'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.6'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:3.7.0'
     implementation 'com.google.code.gson:gson:2.7'
 
-    implementation 'com.simplecityapps:recyclerview-fastscroll:1.0.16'
+    implementation 'com.simplecityapps:recyclerview-fastscroll:1.0.20'
     implementation ('com.h6ah4i.android.widget.verticalseekbar:verticalseekbar:0.5.2') {
         exclude group: 'com.android.support'
         exclude module: 'appcompat-v7'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,8 +95,7 @@ dependencies {
     implementation project(':exoplayer-flac')
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.robolectric:robolectric:3.5.1'
-    testImplementation 'org.robolectric:shadows-support-v4:3.3.2'
+    testImplementation 'org.robolectric:robolectric:4.2.1'
 
     implementation 'com.marverenic.heterogeneousadapter:heterogeneousadapter:1.1'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.marverenic.music">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" /> <!-- Used to play music -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" /> <!-- Used to read music -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- Used to save playlists -->
     <uses-permission android:name="android.permission.INTERNET" /> <!-- Used to fetch data from Last.fm and send bug reports -->

--- a/app/src/main/java/com/marverenic/music/ui/common/ShuffleAllSection.java
+++ b/app/src/main/java/com/marverenic/music/ui/common/ShuffleAllSection.java
@@ -12,12 +12,12 @@ import com.marverenic.music.R;
 import com.marverenic.music.data.store.PreferenceStore;
 import com.marverenic.music.model.Song;
 import com.marverenic.music.player.PlayerController;
-import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView.MeasurableAdapter;
+import com.marverenic.music.view.MeasurableSection;
 
 import java.util.List;
 
 public class ShuffleAllSection extends HeterogeneousAdapter.SingletonSection<List<Song>>
-        implements MeasurableAdapter {
+        implements MeasurableSection {
 
     private PlayerController mPlayerController;
     private PreferenceStore mPrefStore;
@@ -52,7 +52,7 @@ public class ShuffleAllSection extends HeterogeneousAdapter.SingletonSection<Lis
     }
 
     @Override
-    public int getViewTypeHeight(RecyclerView recyclerView, int viewType) {
+    public int getViewTypeHeight(RecyclerView recyclerView) {
         return recyclerView.getResources().getDimensionPixelSize(R.dimen.list_height_small)
                 + recyclerView.getResources().getDimensionPixelSize(R.dimen.divider_height);
     }

--- a/app/src/main/java/com/marverenic/music/ui/common/SpacerSingleton.java
+++ b/app/src/main/java/com/marverenic/music/ui/common/SpacerSingleton.java
@@ -8,10 +8,10 @@ import android.view.ViewGroup;
 import com.marverenic.adapter.EnhancedViewHolder;
 import com.marverenic.adapter.HeterogeneousAdapter;
 import com.marverenic.music.R;
-import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView.MeasurableAdapter;
+import com.marverenic.music.view.MeasurableSection;
 
 public class SpacerSingleton extends HeterogeneousAdapter.SingletonSection<Void>
-        implements MeasurableAdapter {
+        implements MeasurableSection {
 
     private final int mHeight;
     private boolean mVisible;
@@ -52,7 +52,7 @@ public class SpacerSingleton extends HeterogeneousAdapter.SingletonSection<Void>
     }
 
     @Override
-    public int getViewTypeHeight(RecyclerView recyclerView, int viewType) {
+    public int getViewTypeHeight(RecyclerView recyclerView) {
         return mHeight;
     }
 

--- a/app/src/main/java/com/marverenic/music/ui/library/artist/ArtistSection.java
+++ b/app/src/main/java/com/marverenic/music/ui/library/artist/ArtistSection.java
@@ -16,13 +16,13 @@ import com.marverenic.music.databinding.InstanceArtistBinding;
 import com.marverenic.music.model.Artist;
 import com.marverenic.music.model.ModelUtil;
 import com.marverenic.music.player.PlayerController;
-import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView.MeasurableAdapter;
+import com.marverenic.music.view.MeasurableSection;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView.SectionedAdapter;
 
 import java.util.List;
 
 public class ArtistSection extends HeterogeneousAdapter.ListSection<Artist>
-        implements SectionedAdapter, MeasurableAdapter {
+        implements SectionedAdapter, MeasurableSection {
 
     private Context mContext;
     private FragmentManager mFragmentManager;
@@ -63,7 +63,7 @@ public class ArtistSection extends HeterogeneousAdapter.ListSection<Artist>
     }
 
     @Override
-    public int getViewTypeHeight(RecyclerView recyclerView, int viewType) {
+    public int getViewTypeHeight(RecyclerView recyclerView) {
         return recyclerView.getResources().getDimensionPixelSize(R.dimen.list_height)
                 + recyclerView.getResources().getDimensionPixelSize(R.dimen.divider_height);
     }

--- a/app/src/main/java/com/marverenic/music/ui/library/genre/GenreSection.java
+++ b/app/src/main/java/com/marverenic/music/ui/library/genre/GenreSection.java
@@ -16,13 +16,13 @@ import com.marverenic.music.databinding.InstanceGenreBinding;
 import com.marverenic.music.model.Genre;
 import com.marverenic.music.model.ModelUtil;
 import com.marverenic.music.player.PlayerController;
-import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView.MeasurableAdapter;
+import com.marverenic.music.view.MeasurableSection;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView.SectionedAdapter;
 
 import java.util.List;
 
 public class GenreSection extends HeterogeneousAdapter.ListSection<Genre>
-        implements SectionedAdapter, MeasurableAdapter {
+        implements SectionedAdapter, MeasurableSection {
 
     private Context mContext;
     private FragmentManager mFragmentManager;
@@ -63,7 +63,7 @@ public class GenreSection extends HeterogeneousAdapter.ListSection<Genre>
     }
 
     @Override
-    public int getViewTypeHeight(RecyclerView recyclerView, int viewType) {
+    public int getViewTypeHeight(RecyclerView recyclerView) {
         return recyclerView.getResources().getDimensionPixelSize(R.dimen.list_height)
                 + recyclerView.getResources().getDimensionPixelSize(R.dimen.divider_height);
     }

--- a/app/src/main/java/com/marverenic/music/ui/library/playlist/PlaylistSection.java
+++ b/app/src/main/java/com/marverenic/music/ui/library/playlist/PlaylistSection.java
@@ -14,13 +14,13 @@ import com.marverenic.music.databinding.InstancePlaylistBinding;
 import com.marverenic.music.model.ModelUtil;
 import com.marverenic.music.model.Playlist;
 import com.marverenic.music.player.PlayerController;
-import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView.MeasurableAdapter;
+import com.marverenic.music.view.MeasurableSection;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView.SectionedAdapter;
 
 import java.util.List;
 
 public class PlaylistSection extends HeterogeneousAdapter.ListSection<Playlist>
-        implements SectionedAdapter, MeasurableAdapter {
+        implements SectionedAdapter, MeasurableSection {
 
     private Context mContext;
     private PlaylistStore mPlaylistStore;
@@ -55,7 +55,7 @@ public class PlaylistSection extends HeterogeneousAdapter.ListSection<Playlist>
     }
 
     @Override
-    public int getViewTypeHeight(RecyclerView recyclerView, int viewType) {
+    public int getViewTypeHeight(RecyclerView recyclerView) {
         return recyclerView.getResources().getDimensionPixelSize(R.dimen.list_height)
                 + recyclerView.getResources().getDimensionPixelSize(R.dimen.divider_height);
     }

--- a/app/src/main/java/com/marverenic/music/ui/library/song/SongSection.java
+++ b/app/src/main/java/com/marverenic/music/ui/library/song/SongSection.java
@@ -18,7 +18,7 @@ import com.marverenic.music.model.ModelUtil;
 import com.marverenic.music.model.Song;
 import com.marverenic.music.player.PlayerController;
 import com.marverenic.music.ui.common.OnSongSelectedListener;
-import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView.MeasurableAdapter;
+import com.marverenic.music.view.MeasurableSection;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView.SectionedAdapter;
 
 import java.util.List;
@@ -27,7 +27,7 @@ import rx.subjects.BehaviorSubject;
 import timber.log.Timber;
 
 public class SongSection extends HeterogeneousAdapter.ListSection<Song>
-        implements SectionedAdapter, MeasurableAdapter {
+        implements SectionedAdapter, MeasurableSection {
 
     private Context mContext;
     private PlayerController mPlayerController;
@@ -73,12 +73,12 @@ public class SongSection extends HeterogeneousAdapter.ListSection<Song>
     @NonNull
     @Override
     public String getSectionName(int position) {
-        String title = ModelUtil.sortableTitle(get(position).getAlbumName(), mContext.getResources());
+        String title = ModelUtil.sortableTitle(get(position).getSongName(), mContext.getResources());
         return Character.toString(title.charAt(0)).toUpperCase();
     }
 
     @Override
-    public int getViewTypeHeight(RecyclerView recyclerView, int viewType) {
+    public int getViewTypeHeight(RecyclerView recyclerView) {
         return recyclerView.getResources().getDimensionPixelSize(R.dimen.list_height)
                 + recyclerView.getResources().getDimensionPixelSize(R.dimen.divider_height);
     }

--- a/app/src/main/java/com/marverenic/music/view/HeterogeneousFastScrollAdapter.java
+++ b/app/src/main/java/com/marverenic/music/view/HeterogeneousFastScrollAdapter.java
@@ -5,21 +5,20 @@ import android.support.v7.widget.RecyclerView;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView.MeasurableAdapter;
 
 public class HeterogeneousFastScrollAdapter extends HomogeneousFastScrollAdapter
-        implements MeasurableAdapter {
+        implements MeasurableAdapter<RecyclerView.ViewHolder> {
 
     @Override
-    public int getViewTypeHeight(RecyclerView recyclerView, int viewType) {
+    public int getViewTypeHeight(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, int viewType) {
         for (int i = 0; i < getSectionCount(); i++) {
             Section section = getSection(i);
             if (section.getTypeId() == viewType) {
-                if (!(section instanceof MeasurableAdapter)) {
+                if (!(section instanceof MeasurableSection)) {
                     return 0;
                 }
 
-                return ((MeasurableAdapter) section).getViewTypeHeight(recyclerView, 0);
+                return ((MeasurableSection) section).getViewTypeHeight(recyclerView);
             }
         }
         return 0;
     }
-
 }

--- a/app/src/main/java/com/marverenic/music/view/MeasurableSection.java
+++ b/app/src/main/java/com/marverenic/music/view/MeasurableSection.java
@@ -1,0 +1,7 @@
+package com.marverenic.music.view;
+
+import android.support.v7.widget.RecyclerView;
+
+public interface MeasurableSection {
+    int getViewTypeHeight(RecyclerView recyclerView);
+}

--- a/app/src/main/res/drawable/inset_top_shadow.xml
+++ b/app/src/main/res/drawable/inset_top_shadow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient android:type="linear"
-        android:angle="-90"
+        android:angle="270"
         android:centerY="60%"
         android:startColor="#50000000"
         android:centerColor="#12000000"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -234,7 +234,7 @@
     <string name="uses_glide_detail">Versión 3.7.0; distribuido por Google, Inc. bajo una Licencia BSD</string>
     <string name="uses_vert_slider_detail">Versión 0.5.2; distribuido por Haruki Hasegawa bajo una
         Licencia Apache, Versión 2.0</string>
-    <string name="uses_fastscroll_detail">Versión 1.0.16; Distribuido por Tim Malseed bajo una
+    <string name="uses_fastscroll_detail">Versión 1.0.20; Distribuido por Tim Malseed bajo una
         Licencia Apache, Versión 2.0</string>
     <string name="uses_seek_arc_detail">Versión 1.1; distribuido por Triggertrap Ltd
         (Neil Davies) bajo una licencia MIT</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -212,8 +212,8 @@
     <string name="lastfm_header">La información del artista es proporcionada por</string>
     <string name="uses_header">Jockey también utiliza las siguientes bibliotecas de código abierto:</string>
     <string name="uses_aosp_header">Bibliotecas de Soporte de Android</string>
-    <string name="uses_aosp_detail">Support-v4 27.1.0, Appcompat-v7 27.1.0, RecyclerView 27.1.0,
-        CardView 27.1.0, Design 27.1.0, Palette 27.1.0, Preference-v14 27.1.0, Room 1.1.0;
+    <string name="uses_aosp_detail">Support-v4 28.0.0, Appcompat-v7 28.0.0, RecyclerView 28.0.0,
+        CardView 28.0.0, Design 28.0.0, Palette 28.0.0, Preference-v14 28.0.0, Room 1.1.0;
         distribuido por Android Open Source Project bajo una Licencia Apache, Versión 2.0</string>
     <string name="uses_exoplayer_detail">Versión 2.6.1; distribuido por Google Inc. bajo una
         Licencia Apache, Versión 2.0</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -268,7 +268,7 @@
     <string name="uses_gson_detail">Versie 2.7; gedistributeerd door Google, Inc. onder een Apache License, versie 2.0</string>
     <string name="uses_glide_detail">Versie 3.7.0; gedistributeerd door Google, Inc. onder een BSD licensie</string>
     <string name="uses_vert_slider_detail">Versie 0.5.2; gedistributeerd door Haruki Hasegawa onder een Apache License, versie 2.0</string>
-    <string name="uses_fastscroll_detail">Versie 1.0.16; gedistributeerd door Tim Malseed onder een Apache License, versie 2.0</string>
+    <string name="uses_fastscroll_detail">Versie 1.0.20; gedistributeerd door Tim Malseed onder een Apache License, versie 2.0</string>
     <string name="uses_seek_arc_detail">Versie 1.1; gedistributeerd door Triggertrap Ltd (Neil Davies) onder een MIT License</string>
     <string name="uses_timber_detail">Versie 1.1; gedistributeerd door Triggertrap Ltd (Neil Davies) onder een MIT License</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -257,7 +257,7 @@
     <string name="add_shortcut_description">Wil je dat de kleur van Jockey\'s snelkoppling-icoon hetzelfde is als je huidige thema? Jockey zal herstarten en alle icoontjes zullen verwijderd worden.</string>
     <string name="uses_aosp_header">Android Support Libraries</string>
     <string name="uses_header">Jockey gebruikt de volgende open-source onderdelen:</string>
-    <string name="uses_aosp_detail">Support-v4 27.1.0, Appcompat-v7 27.1.0, RecyclerView 27.1.0, CardView 27.1.0, Design 27.1.0, Palette 27.1.0, Preference-v14 27.1.0, Room 1.1.0; gedistributeerd door het Android Open Source Project onder de Apache License, versie 2.0</string>
+    <string name="uses_aosp_detail">Support-v4 28.0.0, Appcompat-v7 28.0.0, RecyclerView 28.0.0, CardView 28.0.0, Design 28.0.0, Palette 28.0.0, Preference-v14 28.0.0, Room 1.1.0; gedistributeerd door het Android Open Source Project onder de Apache License, versie 2.0</string>
     <string name="uses_exoplayer_detail">Versie 2.6.1; gedistributeerd door Google Inc. onder een Apache License, versie 2.0</string>
     <string name="uses_libflac_detail">Version 1.3.1; gedistributeerd door Xiph.Org Foundation onder een BSD licentie</string>
     <string name="uses_dagger_detail">Versie 2.6; gedistributeerd door Google Inc. en Square Inc. onder een Apache License, versie 2.0</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,8 +217,8 @@
     <string name="lastfm_description" translatable="false">Last.fm</string>
     <string name="uses_header">Jockey also uses the following open-source libraries:</string>
     <string name="uses_aosp_header">Android Support Libraries</string>
-    <string name="uses_aosp_detail">Support-v4 27.1.0, Appcompat-v7 27.1.0, RecyclerView 27.1.0,
-        CardView 27.1.0, Design 27.1.0, Palette 27.1.0, Preference-v14 27.1.0, Room 1.1.0;
+    <string name="uses_aosp_detail">Support-v4 28.0.0, Appcompat-v7 28.0.0, RecyclerView 28.0.0,
+        CardView 28.0.0, Design 28.0.0, Palette 28.0.0, Preference-v14 28.0.0, Room 1.1.0;
         distributed by the Android Open Source Project under an Apache License, Version 2.0</string>
     <string name="uses_exoplayer_header" translatable="false">ExoPlayer</string>
     <string name="uses_exoplayer_detail">Version 2.6.1; distributed by Google Inc. under an Apache

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,7 +250,7 @@
     <string name="uses_vert_slider_detail">Version 0.5.2; distributed by Haruki Hasegawa
         under an Apache License, Version 2.0</string>
     <string name="uses_fastscroll_header" translatable="false">RecyclerView FastScroll</string>
-    <string name="uses_fastscroll_detail">Version 1.0.16; distributed by Tim Malseed under an
+    <string name="uses_fastscroll_detail">Version 1.0.20; distributed by Tim Malseed under an
         Apache License, Version 2.0</string>
     <string name="uses_seek_arc_header" translatable="false">SeekArc</string>
     <string name="uses_seek_arc_detail">Version 1.1; distributed by Triggertrap Ltd (Neil Davies)

--- a/app/src/test/java/com/marverenic/music/utils/UtilTest.java
+++ b/app/src/test/java/com/marverenic/music/utils/UtilTest.java
@@ -2,14 +2,11 @@ package com.marverenic.music.utils;
 
 import android.webkit.MimeTypeMap;
 
-import com.marverenic.music.BuildConfig;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.io.File;
 
@@ -18,7 +15,6 @@ import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class)
 public class UtilTest {
 
     @Before

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ allprojects {
 }
 
 ext {
-    targetSdkVersion = 27
-    supportLibVersion = '27.1.0'
+    targetSdkVersion = 28
+    supportLibVersion = '28.0.0'
     exoplayerVersion = '2.6.1'
     roomVersion = '1.1.0'
 }


### PR DESCRIPTION
Completes [#160705000](https://www.pivotaltracker.com/story/show/160705000).

This bumps the targetSdk version to API level 28, to add support for Android Pie. There were a number of dependency changes that were required to satisfy Gradle (some of which were caused by conflicting dependency versions). 

### Testing Steps
This would require a full regression test, but because this isn't going to be part of the initial 3.0 release, there is going to be a lot of time to test the implications of this library bump. Everything seems to be working as-is, but there are known changes to the preferences support library that are affecting its appearance. This work is tracked in [#144999499](https://www.pivotaltracker.com/story/show/144999499).