### PR TITLE
Fix incorrect fast scroll label

### DIFF
--- a/app/src/main/java/com/marverenic/music/ui/library/song/SongSection.java
+++ b/app/src/main/java/com/marverenic/music/ui/library/song/SongSection.java
@@ -73,7 +73,7 @@ public class SongSection extends HeterogeneousAdapter.ListSection<Song>
     @NonNull
     @Override
     public String getSectionName(int position) {
-        String title = ModelUtil.sortableTitle(get(position).getAlbumName(), mContext.getResources());
+        String title = ModelUtil.sortableTitle(get(position).getSongName(), mContext.getResources());
         return Character.toString(title.charAt(0)).toUpperCase();
     }
 


### PR DESCRIPTION
Completes [#166892253](https://www.pivotaltracker.com/story/show/166892253).

### Testing Steps
Verify that dragging the scrollbar on the songs tab of the library page shows the first letter of the song title, ignoring prefixes that are overlooked in the sorting order.