### PR TITLE
Fixes scrollbar thumb color issue

### DIFF
--- a/app/src/main/res/layout/fragment_library_page.xml
+++ b/app/src/main/res/layout/fragment_library_page.xml
@@ -11,4 +11,5 @@
     app:fastScrollPopupBgColor="?attr/colorAccent"
     app:fastScrollPopupTextColor="?android:attr/textColorPrimaryInverse"
     app:fastScrollThumbColor="?attr/colorAccent"
+    app:fastScrollThumbInactiveColor="?attr/colorAccent"                                                                
     app:layout_behavior="@string/appbar_scrolling_view_behavior"/>


### PR DESCRIPTION
Fixes issue when scrollbar thumb was nearly invisible due to its color

Pivotal tracker link : https://www.pivotaltracker.com/story/show/167117735

### Testing Steps
Change to dark mode in settings and observe the scrollbar thumb is visible in main screen fragments.
