### PR TITLE
Fix the settings screen layout issue

### DIFF
--- a/app/src/main/res/values-sw360dp-v13/preference.xml
+++ b/app/src/main/res/values-sw360dp-v13/preference.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--Created By Me to fix the appearance issue caused by migrating to AndroidX-->
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <bool name="config_materialPreferenceIconSpaceReserved" tools:ignore="MissingDefaultResource,PrivateResource">false</bool>
+    <dimen name="preference_category_padding_start" tools:ignore="MissingDefaultResource,PrivateResource">0dp</dimen>
+</resources>


### PR DESCRIPTION

![Screenshot_2019-07-29-08-39-48-926_com dv apps purpleplayerpro](https://user-images.githubusercontent.com/29792433/62019483-aaeb9c80-b1dc-11e9-80f0-125b5f1616f2.png)
After migrating to AndroidX, The icon space is reserved by default in preference screens. This behavior is fixed by overriding the preference file.

### Testing Steps
Open the Settings from the App and observe the space in the left is gone.

Update: Screenshot attached of the Settings screen. I dont have previous version of app on my phone now, but I guess you already know the issue.
