### PR TITLE
Bump target SDK to API level 29

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         android:name=".JockeyApplication"
         android:resizeableActivity="true"
         android:supportsRtl="true"
+        android:requestLegacyExternalStorage="true"
         tools:ignore="GoogleAppIndexingWarning,UnusedAttribute">
 
         <!-- Library Activity -->

--- a/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
+++ b/app/src/main/java/com/marverenic/music/player/MusicPlayer.java
@@ -14,14 +14,15 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.PowerManager;
-import androidx.annotation.NonNull;
 import android.support.v4.media.MediaDescriptionCompat;
 import android.support.v4.media.MediaMetadataCompat;
-import androidx.media.session.MediaButtonReceiver;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.MediaSessionCompat.QueueItem;
 import android.support.v4.media.session.PlaybackStateCompat;
 import android.view.KeyEvent;
+
+import androidx.annotation.NonNull;
+import androidx.media.session.MediaButtonReceiver;
 
 import com.marverenic.music.BuildConfig;
 import com.marverenic.music.JockeyApplication;
@@ -1267,7 +1268,7 @@ public class MusicPlayer implements AudioManager.OnAudioFocusChangeListener,
         for (MusicPlayerExtension ext : mExtensions) {
             ext.onSongStarted(this);
         }
-        Util.fetchArtwork(mContext, getNowPlaying().getLocation())
+        Util.fetchArtwork(mContext, getNowPlaying())
                 .subscribeOn(Schedulers.io())
                 .subscribe(artwork -> {
                     mArtwork = artwork;

--- a/app/src/main/java/com/marverenic/music/ui/browse/ThumbnailLoader.java
+++ b/app/src/main/java/com/marverenic/music/ui/browse/ThumbnailLoader.java
@@ -2,7 +2,7 @@ package com.marverenic.music.ui.browse;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.net.Uri;
+
 import androidx.collection.ArrayMap;
 
 import com.marverenic.music.R;
@@ -18,7 +18,7 @@ import rx.schedulers.Schedulers;
 /**
  * A utility class that is shared among a list of file views in a recycler view, and is responsible
  * for caching and managing requests to load song thumbnails. Ideally, we'd just use Glide's
- * implementation, but we use {@link com.marverenic.music.utils.Util#fetchArtwork(Context, Uri)},
+ * implementation, but we use {@link Util#fetchThumbnailFromFile(Context, File, int)}.
  * There's no way for Glide to skip the read step – the metadata is used as the primary source,
  * which can't be read from Glide.
  *
@@ -92,8 +92,7 @@ class ThumbnailLoader {
     }
 
     private Observable<Bitmap> loadBitmap(File file) {
-        Uri fileUri = Uri.fromFile(file);
-        Observable<Bitmap> image = Util.fetchArtwork(mContext, fileUri, mThumbnailResolution, false)
+        Observable<Bitmap> image = Util.fetchThumbnailFromFile(mContext, file, mThumbnailResolution)
                 .subscribeOn(Schedulers.io())
                 .doOnNext(bitmap -> {
                     synchronized (mLock) {

--- a/app/src/main/java/com/marverenic/music/ui/library/album/contents/AlbumViewModel.java
+++ b/app/src/main/java/com/marverenic/music/ui/library/album/contents/AlbumViewModel.java
@@ -1,11 +1,16 @@
 package com.marverenic.music.ui.library.album.contents;
 
+import android.content.ContentUris;
 import android.content.Context;
-import androidx.databinding.Bindable;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.MediaStore;
+import android.util.DisplayMetrics;
+
 import androidx.annotation.Nullable;
+import androidx.databinding.Bindable;
 import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.RecyclerView;
-import android.util.DisplayMetrics;
 
 import com.bumptech.glide.GenericRequestBuilder;
 import com.bumptech.glide.Glide;
@@ -22,6 +27,7 @@ import com.marverenic.music.ui.common.BasicEmptyState;
 import com.marverenic.music.ui.common.OnSongSelectedListener;
 import com.marverenic.music.ui.common.ShuffleAllSection;
 import com.marverenic.music.ui.library.song.SongSection;
+import com.marverenic.music.utils.MediaStoreThumbnailLoader;
 import com.marverenic.music.view.BackgroundDecoration;
 import com.marverenic.music.view.DividerDecoration;
 
@@ -83,7 +89,20 @@ public class AlbumViewModel extends BaseViewModel {
 
     @Bindable
     public GenericRequestBuilder getHeroImage() {
-        return Glide.with(getContext()).load(mAlbum.getArtUri()).centerCrop();
+        if (Build.VERSION.SDK_INT >= 29) {
+            Uri thumbnailUri = ContentUris.withAppendedId(
+                    MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI,
+                    mAlbum.getAlbumId()
+            );
+
+            return Glide.with(getContext())
+                    .using(new MediaStoreThumbnailLoader(getContext()))
+                    .load(thumbnailUri)
+                    .decoder(new MediaStoreThumbnailLoader.Decoder(getContext()))
+                    .centerCrop();
+        } else {
+            return Glide.with(getContext()).load(mAlbum.getArtUri()).centerCrop();
+        }
     }
 
     @Bindable

--- a/app/src/main/java/com/marverenic/music/utils/MediaStoreThumbnailLoader.kt
+++ b/app/src/main/java/com/marverenic/music/utils/MediaStoreThumbnailLoader.kt
@@ -55,6 +55,24 @@ class MediaStoreThumbnailLoader(
         override fun getId() = ""
     }
 
+    class BitmapDecoder private constructor(
+        private val bitmapPool: BitmapPool
+    ) : ResourceDecoder<ImageVideoWrapper, Bitmap> {
+
+        constructor(context: Context): this(Glide.get(context).bitmapPool)
+
+        override fun decode(source: ImageVideoWrapper?, width: Int, height: Int): Resource<Bitmap> {
+            val inputStream = source?.stream
+            require(inputStream is MediaStoreThumbnailInputStream) {
+                "This decoder can only be used with MediaStoreThumbnailLoader."
+            }
+
+            return BitmapResource(inputStream.bitmap, bitmapPool)
+        }
+
+        override fun getId() = ""
+    }
+
 }
 
 @TargetApi(29)

--- a/app/src/main/java/com/marverenic/music/utils/MediaStoreThumbnailLoader.kt
+++ b/app/src/main/java/com/marverenic/music/utils/MediaStoreThumbnailLoader.kt
@@ -1,0 +1,98 @@
+package com.marverenic.music.utils
+
+import android.annotation.TargetApi
+import android.content.ContentResolver
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.CancellationSignal
+import android.util.Size
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Priority
+import com.bumptech.glide.load.ResourceDecoder
+import com.bumptech.glide.load.data.DataFetcher
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
+import com.bumptech.glide.load.model.ImageVideoWrapper
+import com.bumptech.glide.load.model.stream.StreamModelLoader
+import com.bumptech.glide.load.resource.bitmap.BitmapResource
+import com.bumptech.glide.load.resource.gifbitmap.GifBitmapWrapper
+import com.bumptech.glide.load.resource.gifbitmap.GifBitmapWrapperResource
+import java.io.InputStream
+
+@TargetApi(29)
+class MediaStoreThumbnailLoader(
+    private val context: Context
+) : StreamModelLoader<Uri> {
+
+    override fun getResourceFetcher(model: Uri?, width: Int, height: Int): DataFetcher<InputStream>? {
+        return model?.let {
+            MediaStoreThumbnailDataFetcher(
+                contentResolver = context.contentResolver,
+                uri = it,
+                width = width,
+                height = height
+            )
+        }
+    }
+
+    class Decoder private constructor(
+        private val bitmapPool: BitmapPool
+    ) : ResourceDecoder<ImageVideoWrapper, GifBitmapWrapper> {
+
+        constructor(context: Context): this(Glide.get(context).bitmapPool)
+
+        override fun decode(source: ImageVideoWrapper?, width: Int, height: Int): Resource<GifBitmapWrapper> {
+            val inputStream = source?.stream
+            require(inputStream is MediaStoreThumbnailInputStream) {
+                "This decoder can only be used with MediaStoreThumbnailLoader."
+            }
+
+            val bitmapResource = BitmapResource(inputStream.bitmap, bitmapPool)
+            return GifBitmapWrapperResource(GifBitmapWrapper(bitmapResource, null))
+        }
+
+        override fun getId() = ""
+    }
+
+}
+
+@TargetApi(29)
+private class MediaStoreThumbnailDataFetcher(
+    private val contentResolver: ContentResolver,
+    private val uri: Uri,
+    private val width: Int,
+    private val height: Int
+) : DataFetcher<InputStream> {
+
+    private val cancellationSignal = CancellationSignal()
+
+    override fun loadData(priority: Priority?): InputStream {
+        val image = contentResolver.loadThumbnail(uri, Size(width, height), cancellationSignal)
+        return MediaStoreThumbnailInputStream(image)
+    }
+
+    override fun cleanup() {
+
+    }
+
+    override fun getId(): String {
+        return "$uri[$width, $height]"
+    }
+
+    override fun cancel() {
+        cancellationSignal.cancel()
+    }
+
+}
+
+// This is a complete hack to make Glide play nicely with what I'm trying to get it to do.
+private class MediaStoreThumbnailInputStream(
+    val bitmap: Bitmap
+) : InputStream() {
+
+    // Not actually used. The reader will cast the IS to this class and read the bitmap directly
+    // to avoid a pointless in-memory copy.
+    override fun read() = -1
+
+}

--- a/app/src/main/java/com/marverenic/music/utils/MediaStoreThumbnailLoader.kt
+++ b/app/src/main/java/com/marverenic/music/utils/MediaStoreThumbnailLoader.kt
@@ -25,7 +25,11 @@ class MediaStoreThumbnailLoader(
     private val context: Context
 ) : StreamModelLoader<Uri> {
 
-    override fun getResourceFetcher(model: Uri?, width: Int, height: Int): DataFetcher<InputStream>? {
+    override fun getResourceFetcher(
+        model: Uri?,
+        width: Int,
+        height: Int
+    ): DataFetcher<InputStream>? {
         return model?.let {
             MediaStoreThumbnailDataFetcher(
                 contentResolver = context.contentResolver,
@@ -40,9 +44,13 @@ class MediaStoreThumbnailLoader(
         private val bitmapPool: BitmapPool
     ) : ResourceDecoder<ImageVideoWrapper, GifBitmapWrapper> {
 
-        constructor(context: Context): this(Glide.get(context).bitmapPool)
+        constructor(context: Context) : this(Glide.get(context).bitmapPool)
 
-        override fun decode(source: ImageVideoWrapper?, width: Int, height: Int): Resource<GifBitmapWrapper> {
+        override fun decode(
+            source: ImageVideoWrapper?,
+            width: Int,
+            height: Int
+        ): Resource<GifBitmapWrapper> {
             val inputStream = source?.stream
             require(inputStream is MediaStoreThumbnailInputStream) {
                 "This decoder can only be used with MediaStoreThumbnailLoader."
@@ -59,7 +67,7 @@ class MediaStoreThumbnailLoader(
         private val bitmapPool: BitmapPool
     ) : ResourceDecoder<ImageVideoWrapper, Bitmap> {
 
-        constructor(context: Context): this(Glide.get(context).bitmapPool)
+        constructor(context: Context) : this(Glide.get(context).bitmapPool)
 
         override fun decode(source: ImageVideoWrapper?, width: Int, height: Int): Resource<Bitmap> {
             val inputStream = source?.stream
@@ -72,7 +80,6 @@ class MediaStoreThumbnailLoader(
 
         override fun getId() = ""
     }
-
 }
 
 @TargetApi(29)
@@ -91,7 +98,6 @@ private class MediaStoreThumbnailDataFetcher(
     }
 
     override fun cleanup() {
-
     }
 
     override fun getId(): String {
@@ -101,7 +107,6 @@ private class MediaStoreThumbnailDataFetcher(
     override fun cancel() {
         cancellationSignal.cancel()
     }
-
 }
 
 // This is a complete hack to make Glide play nicely with what I'm trying to get it to do.
@@ -112,5 +117,4 @@ private class MediaStoreThumbnailInputStream(
     // Not actually used. The reader will cast the IS to this class and read the bitmap directly
     // to avoid a pointless in-memory copy.
     override fun read() = -1
-
 }

--- a/app/src/main/res/layout/fragment_album.xml
+++ b/app/src/main/res/layout/fragment_album.xml
@@ -39,6 +39,7 @@
                         android:layout_height="wrap_content"
                         app:height="@{viewModel.heroImageHeight}"
                         android:src="@{viewModel.heroImage}"
+                        android:scaleType="centerCrop"
                         android:fitsSystemWindows="true"
                         android:contentDescription="@null"/>
 

--- a/app/src/main/res/layout/fragment_music_browser.xml
+++ b/app/src/main/res/layout/fragment_music_browser.xml
@@ -37,7 +37,7 @@
                 android:clipToPadding="false"
                 android:scrollbars="none"
                 app:breadCrumbs="@{viewModel.breadCrumbs}"
-                app:selectedCrumb="@{viewModel.selectedBreadCrumb}"/>
+                app:selectedCrumb="@={viewModel.selectedBreadCrumb}"/>
 
         </com.google.android.material.appbar.AppBarLayout>
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ allprojects {
 ext {
     isCiBuild = project.hasProperty('ciBuild')
 
-    targetSdkVersion = 28
-    compileSdkVersion = 28
+    targetSdkVersion = 29
+    compileSdkVersion = targetSdkVersion
 
     versions = [
         kotlin : kotlinVersion,


### PR DESCRIPTION
This PR bumps the app's target SDK to API level 29, which is the minimum that Google Play is currently accepting for application updates at this time. It also fixes a few issues around album artwork and folder navigation.

Ideally, Jockey would support API 30, but the scoped storage changes are making it difficult to maintain the app. It is very unlikely that Jockey's current incarnation will be updated after November 2021, which is presumably when Google will bump the target SDK requirement to API level 30. Jockey will live on, however, after a full rewrite which is currently ongoing.
